### PR TITLE
feat: add arcan-praxis bridge for canonical tool execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,13 +62,16 @@ dependencies = [
  "anyhow",
  "chrono",
  "hex",
+ "opentelemetry",
  "parking_lot",
  "serde",
  "serde_json",
  "sha2",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "uuid",
+ "vigil",
 ]
 
 [[package]]
@@ -183,6 +186,7 @@ dependencies = [
  "arcan-core",
  "arcan-harness",
  "arcan-lago",
+ "arcan-praxis",
  "arcan-provider",
  "arcan-spaces",
  "arcan-tui",
@@ -299,6 +303,20 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "arcan-praxis"
+version = "0.2.1"
+dependencies = [
+ "aios-protocol",
+ "arcan-core",
+ "arcan-harness",
+ "praxis-core",
+ "praxis-tools",
+ "serde_json",
+ "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/arcan-console",
   "crates/arcan-core",
   "crates/arcan-harness",
+  "crates/arcan-praxis",
   "crates/arcan-aios-adapters",
   "crates/arcan-store",
   "crates/arcan-provider",

--- a/crates/arcan-praxis/Cargo.toml
+++ b/crates/arcan-praxis/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "arcan-praxis"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Bridge crate: configures and registers Praxis canonical tools into Arcan's runtime"
+readme = "../../README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+arcan-core = { path = "../arcan-core", version = "0.2.1" }
+arcan-harness = { path = "../arcan-harness", version = "0.2.1" }
+aios-protocol.workspace = true
+praxis-core.workspace = true
+praxis-tools.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+tempfile = "3"

--- a/crates/arcan-praxis/src/config.rs
+++ b/crates/arcan-praxis/src/config.rs
@@ -1,0 +1,145 @@
+//! Configuration for the Praxis tool integration.
+//!
+//! [`PraxisConfig`] captures the workspace root, sandbox constraints,
+//! and optional memory directory for constructing Praxis tools.
+
+use aios_protocol::sandbox::NetworkPolicy;
+use praxis_core::sandbox::SandboxPolicy;
+use praxis_core::workspace::FsPolicy;
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+/// Configuration for wiring Praxis tools into Arcan.
+///
+/// Captures workspace root (for FsPolicy) and sandbox constraints
+/// (for SandboxPolicy / BashTool). All fields have sensible defaults.
+#[derive(Debug, Clone)]
+pub struct PraxisConfig {
+    /// Root directory for workspace boundary enforcement.
+    pub workspace_root: PathBuf,
+    /// Whether shell (bash) tool execution is enabled.
+    pub shell_enabled: bool,
+    /// Network access policy for sandboxed commands.
+    pub network: NetworkPolicy,
+    /// Environment variables allowed through the sandbox.
+    pub allowed_env: BTreeSet<String>,
+    /// Maximum command execution time in milliseconds.
+    pub max_execution_ms: u64,
+    /// Maximum stdout size in bytes.
+    pub max_stdout_bytes: usize,
+    /// Maximum stderr size in bytes.
+    pub max_stderr_bytes: usize,
+    /// Optional directory for agent memory files.
+    /// When `None`, memory tools are not registered.
+    pub memory_dir: Option<PathBuf>,
+}
+
+impl PraxisConfig {
+    /// Create a config with the given workspace root and sensible defaults.
+    pub fn new(workspace_root: impl Into<PathBuf>) -> Self {
+        Self {
+            workspace_root: workspace_root.into(),
+            shell_enabled: true,
+            network: NetworkPolicy::Disabled,
+            allowed_env: BTreeSet::from([
+                "PATH".to_string(),
+                "HOME".to_string(),
+                "LANG".to_string(),
+                "TERM".to_string(),
+            ]),
+            max_execution_ms: 120_000,
+            max_stdout_bytes: 512 * 1024,
+            max_stderr_bytes: 512 * 1024,
+            memory_dir: None,
+        }
+    }
+
+    /// Set a memory directory for agent memory tools.
+    pub fn with_memory_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.memory_dir = Some(dir.into());
+        self
+    }
+
+    /// Disable shell execution.
+    pub fn with_shell_disabled(mut self) -> Self {
+        self.shell_enabled = false;
+        self
+    }
+
+    /// Set the network policy.
+    pub fn with_network(mut self, policy: NetworkPolicy) -> Self {
+        self.network = policy;
+        self
+    }
+
+    /// Set the maximum command execution time in milliseconds.
+    pub fn with_max_execution_ms(mut self, ms: u64) -> Self {
+        self.max_execution_ms = ms;
+        self
+    }
+
+    /// Build an [`FsPolicy`] from this config.
+    pub fn fs_policy(&self) -> FsPolicy {
+        FsPolicy::new(&self.workspace_root)
+    }
+
+    /// Build a [`SandboxPolicy`] from this config.
+    pub fn sandbox_policy(&self) -> SandboxPolicy {
+        SandboxPolicy {
+            workspace_root: self.workspace_root.clone(),
+            shell_enabled: self.shell_enabled,
+            network: self.network.clone(),
+            allowed_env: self.allowed_env.clone(),
+            max_execution_ms: self.max_execution_ms,
+            max_stdout_bytes: self.max_stdout_bytes,
+            max_stderr_bytes: self.max_stderr_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn config_defaults_are_sensible() {
+        let config = PraxisConfig::new("/tmp/workspace");
+        assert!(config.shell_enabled);
+        assert!(config.memory_dir.is_none());
+        assert_eq!(config.max_execution_ms, 120_000);
+        assert!(config.allowed_env.contains("PATH"));
+        assert!(config.allowed_env.contains("HOME"));
+    }
+
+    #[test]
+    fn config_builder_methods() {
+        let config = PraxisConfig::new("/tmp/workspace")
+            .with_memory_dir("/tmp/memory")
+            .with_shell_disabled()
+            .with_max_execution_ms(30_000);
+
+        assert!(!config.shell_enabled);
+        assert_eq!(config.memory_dir.as_deref(), Some(Path::new("/tmp/memory")));
+        assert_eq!(config.max_execution_ms, 30_000);
+    }
+
+    #[test]
+    fn fs_policy_from_config() {
+        let config = PraxisConfig::new("/tmp/workspace");
+        let policy = config.fs_policy();
+        assert_eq!(policy.workspace_root(), Path::new("/tmp/workspace"));
+    }
+
+    #[test]
+    fn sandbox_policy_from_config() {
+        let config = PraxisConfig::new("/tmp/workspace")
+            .with_shell_disabled()
+            .with_max_execution_ms(5000);
+
+        let policy = config.sandbox_policy();
+        assert!(!policy.shell_enabled);
+        assert_eq!(policy.max_execution_ms, 5000);
+        assert_eq!(policy.workspace_root, PathBuf::from("/tmp/workspace"));
+    }
+}

--- a/crates/arcan-praxis/src/lib.rs
+++ b/crates/arcan-praxis/src/lib.rs
@@ -1,0 +1,38 @@
+//! # arcan-praxis — Praxis Tool Integration for Arcan
+//!
+//! Configures and registers the full suite of Praxis canonical tools
+//! (filesystem, editing, shell, memory) into Arcan's [`ToolRegistry`],
+//! bridging them through the [`PraxisToolBridge`] adapter from arcan-harness.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use arcan_praxis::{PraxisConfig, register_praxis_tools};
+//! use arcan_core::runtime::ToolRegistry;
+//!
+//! let config = PraxisConfig::new("/path/to/workspace");
+//! let mut registry = ToolRegistry::default();
+//! register_praxis_tools(&config, &mut registry);
+//! ```
+//!
+//! ## Architecture
+//!
+//! This crate is intentionally thin. It:
+//! 1. Accepts a [`PraxisConfig`] that captures workspace root + sandbox constraints
+//! 2. Constructs Praxis tool instances with the appropriate [`FsPolicy`] and [`SandboxPolicy`]
+//! 3. Wraps each tool in [`PraxisToolBridge`] to satisfy `arcan_core::runtime::Tool`
+//! 4. Registers them all into an Arcan [`ToolRegistry`]
+//!
+//! The actual tool implementations live in `praxis-tools`. The adapter lives
+//! in `arcan-harness`. This crate is the glue that wires them together.
+
+pub mod config;
+pub mod registry;
+
+pub use config::PraxisConfig;
+pub use registry::register_praxis_tools;
+
+// Re-export key types for convenience.
+pub use arcan_harness::bridge::PraxisToolBridge;
+pub use praxis_core::sandbox::SandboxPolicy;
+pub use praxis_core::workspace::FsPolicy;

--- a/crates/arcan-praxis/src/registry.rs
+++ b/crates/arcan-praxis/src/registry.rs
@@ -1,0 +1,491 @@
+//! Tool registration: builds and registers Praxis tools into Arcan's registry.
+//!
+//! The [`register_praxis_tools`] function is the primary entry point.
+//! It constructs all canonical Praxis tools from a [`PraxisConfig`],
+//! wraps each in a [`PraxisToolBridge`], and registers them into an
+//! Arcan [`ToolRegistry`].
+
+use crate::config::PraxisConfig;
+use arcan_core::runtime::ToolRegistry;
+use arcan_harness::bridge::PraxisToolBridge;
+use praxis_core::local_fs::LocalFs;
+use praxis_core::sandbox::LocalCommandRunner;
+use praxis_tools::edit::EditFileTool;
+use praxis_tools::fs::{GlobTool, GrepTool, ListDirTool, ReadFileTool, WriteFileTool};
+use praxis_tools::memory::{ReadMemoryTool, WriteMemoryTool};
+use praxis_tools::shell::BashTool;
+use std::sync::Arc;
+use tracing::info;
+
+/// Register all Praxis canonical tools into an Arcan [`ToolRegistry`].
+///
+/// Tools registered:
+/// - `read_file` — Read files with hashline tags
+/// - `write_file` — Write files within workspace boundary
+/// - `edit_file` — Hashline (Blake3) content-addressed editing
+/// - `list_dir` — List directory contents
+/// - `glob` — Pattern-based file search
+/// - `grep` — Regex search within file contents
+/// - `bash` — Shell command execution (sandbox-constrained)
+/// - `read_memory` / `write_memory` — Agent memory (if memory_dir configured)
+///
+/// Returns the number of tools registered.
+pub fn register_praxis_tools(config: &PraxisConfig, registry: &mut ToolRegistry) -> usize {
+    let fs_policy = config.fs_policy();
+    let fs: Arc<dyn praxis_core::FsPort> = Arc::new(LocalFs::new(fs_policy));
+
+    let mut count = 0;
+
+    // Filesystem tools
+    registry.register(PraxisToolBridge::new(ReadFileTool::new(fs.clone())));
+    count += 1;
+
+    registry.register(PraxisToolBridge::new(WriteFileTool::new(fs.clone())));
+    count += 1;
+
+    registry.register(PraxisToolBridge::new(ListDirTool::new(fs.clone())));
+    count += 1;
+
+    registry.register(PraxisToolBridge::new(GlobTool::new(fs.clone())));
+    count += 1;
+
+    registry.register(PraxisToolBridge::new(GrepTool::new(fs.clone())));
+    count += 1;
+
+    // Editing tool (hashline / Blake3)
+    registry.register(PraxisToolBridge::new(EditFileTool::new(fs)));
+    count += 1;
+
+    // Shell tool (sandbox-constrained)
+    let sandbox_policy = config.sandbox_policy();
+    let runner = Box::new(LocalCommandRunner::new());
+    registry.register(PraxisToolBridge::new(BashTool::new(sandbox_policy, runner)));
+    count += 1;
+
+    // Memory tools (optional — only if memory_dir is configured)
+    if let Some(ref memory_dir) = config.memory_dir {
+        registry.register(PraxisToolBridge::new(ReadMemoryTool::new(
+            memory_dir.clone(),
+        )));
+        count += 1;
+
+        registry.register(PraxisToolBridge::new(WriteMemoryTool::new(
+            memory_dir.clone(),
+        )));
+        count += 1;
+    }
+
+    info!(
+        tools_registered = count,
+        workspace = %config.workspace_root.display(),
+        memory = config.memory_dir.is_some(),
+        shell = config.shell_enabled,
+        "praxis tools registered in arcan registry"
+    );
+
+    count
+}
+
+/// Return the list of tool names that [`register_praxis_tools`] will register.
+///
+/// Useful for documentation and validation without constructing real tools.
+pub fn praxis_tool_names(include_memory: bool) -> Vec<&'static str> {
+    let mut names = vec![
+        "read_file",
+        "write_file",
+        "list_dir",
+        "glob",
+        "grep",
+        "edit_file",
+        "bash",
+    ];
+    if include_memory {
+        names.push("read_memory");
+        names.push("write_memory");
+    }
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PraxisConfig;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn make_config(dir: &TempDir) -> PraxisConfig {
+        PraxisConfig::new(dir.path())
+    }
+
+    fn make_config_with_memory(dir: &TempDir) -> PraxisConfig {
+        PraxisConfig::new(dir.path()).with_memory_dir(dir.path().join("memory"))
+    }
+
+    #[test]
+    fn registers_core_tools() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(&dir);
+        let mut registry = ToolRegistry::default();
+
+        let count = register_praxis_tools(&config, &mut registry);
+
+        // 7 tools without memory (read_file, write_file, list_dir, glob, grep, edit_file, bash)
+        assert_eq!(count, 7);
+
+        // Verify each tool is accessible
+        assert!(registry.get("read_file").is_some());
+        assert!(registry.get("write_file").is_some());
+        assert!(registry.get("list_dir").is_some());
+        assert!(registry.get("glob").is_some());
+        assert!(registry.get("grep").is_some());
+        assert!(registry.get("edit_file").is_some());
+        assert!(registry.get("bash").is_some());
+
+        // Memory tools not registered
+        assert!(registry.get("read_memory").is_none());
+        assert!(registry.get("write_memory").is_none());
+    }
+
+    #[test]
+    fn registers_memory_tools_when_configured() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config_with_memory(&dir);
+        let mut registry = ToolRegistry::default();
+
+        let count = register_praxis_tools(&config, &mut registry);
+
+        // 9 tools with memory
+        assert_eq!(count, 9);
+
+        assert!(registry.get("read_memory").is_some());
+        assert!(registry.get("write_memory").is_some());
+    }
+
+    #[test]
+    fn tool_definitions_are_valid() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(&dir);
+        let mut registry = ToolRegistry::default();
+        register_praxis_tools(&config, &mut registry);
+
+        let defs = registry.definitions();
+        for def in &defs {
+            assert!(!def.name.is_empty(), "tool name should not be empty");
+            assert!(
+                !def.description.is_empty(),
+                "tool description should not be empty"
+            );
+            assert!(
+                def.input_schema.is_object(),
+                "input_schema should be a JSON object for {}",
+                def.name
+            );
+        }
+    }
+
+    #[test]
+    fn praxis_tool_names_without_memory() {
+        let names = praxis_tool_names(false);
+        assert_eq!(names.len(), 7);
+        assert!(names.contains(&"read_file"));
+        assert!(names.contains(&"bash"));
+        assert!(!names.contains(&"read_memory"));
+    }
+
+    #[test]
+    fn praxis_tool_names_with_memory() {
+        let names = praxis_tool_names(true);
+        assert_eq!(names.len(), 9);
+        assert!(names.contains(&"read_memory"));
+        assert!(names.contains(&"write_memory"));
+    }
+
+    #[test]
+    fn read_file_through_bridge_works() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("hello.txt"), "world").unwrap();
+
+        let config = make_config(&dir);
+        let mut registry = ToolRegistry::default();
+        register_praxis_tools(&config, &mut registry);
+
+        let tool = registry.get("read_file").unwrap();
+        let ctx = arcan_core::runtime::ToolContext {
+            run_id: "test-run".into(),
+            session_id: "test-session".into(),
+            iteration: 1,
+        };
+        let call = arcan_core::protocol::ToolCall {
+            call_id: "call-1".into(),
+            tool_name: "read_file".into(),
+            input: json!({"path": "hello.txt"}),
+        };
+
+        let result = tool.execute(&call, &ctx).unwrap();
+        assert!(!result.is_error);
+        let content = result.output["content"].as_str().unwrap();
+        assert!(content.contains("world"));
+    }
+
+    #[test]
+    fn write_file_through_bridge_works() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(&dir);
+        let mut registry = ToolRegistry::default();
+        register_praxis_tools(&config, &mut registry);
+
+        let tool = registry.get("write_file").unwrap();
+        let ctx = arcan_core::runtime::ToolContext {
+            run_id: "test-run".into(),
+            session_id: "test-session".into(),
+            iteration: 1,
+        };
+        let call = arcan_core::protocol::ToolCall {
+            call_id: "call-2".into(),
+            tool_name: "write_file".into(),
+            input: json!({"path": "output.txt", "content": "hello from bridge"}),
+        };
+
+        let result = tool.execute(&call, &ctx).unwrap();
+        assert!(!result.is_error);
+        assert_eq!(result.output["success"], true);
+
+        // Verify file was actually written
+        let written = std::fs::read_to_string(dir.path().join("output.txt")).unwrap();
+        assert_eq!(written, "hello from bridge");
+    }
+
+    #[test]
+    fn bash_through_bridge_works() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(&dir);
+        let mut registry = ToolRegistry::default();
+        register_praxis_tools(&config, &mut registry);
+
+        let tool = registry.get("bash").unwrap();
+        let ctx = arcan_core::runtime::ToolContext {
+            run_id: "test-run".into(),
+            session_id: "test-session".into(),
+            iteration: 1,
+        };
+        let call = arcan_core::protocol::ToolCall {
+            call_id: "call-3".into(),
+            tool_name: "bash".into(),
+            input: json!({"command": "echo bridge-test"}),
+        };
+
+        let result = tool.execute(&call, &ctx).unwrap();
+        assert!(!result.is_error);
+        assert_eq!(result.output["exit_code"], 0);
+        assert!(
+            result.output["stdout"]
+                .as_str()
+                .unwrap()
+                .contains("bridge-test")
+        );
+    }
+
+    #[test]
+    fn glob_through_bridge_works() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "fn test() {}").unwrap();
+        std::fs::write(dir.path().join("c.txt"), "text file").unwrap();
+
+        let config = make_config(&dir);
+        let mut registry = ToolRegistry::default();
+        register_praxis_tools(&config, &mut registry);
+
+        let tool = registry.get("glob").unwrap();
+        let ctx = arcan_core::runtime::ToolContext {
+            run_id: "test-run".into(),
+            session_id: "test-session".into(),
+            iteration: 1,
+        };
+        let call = arcan_core::protocol::ToolCall {
+            call_id: "call-4".into(),
+            tool_name: "glob".into(),
+            input: json!({"pattern": "*.rs"}),
+        };
+
+        let result = tool.execute(&call, &ctx).unwrap();
+        assert!(!result.is_error);
+        assert_eq!(result.output["count"], 2);
+    }
+
+    #[test]
+    fn grep_through_bridge_works() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("code.rs"),
+            "fn main() {\n    println!(\"hello\");\n}\n",
+        )
+        .unwrap();
+
+        let config = make_config(&dir);
+        let mut registry = ToolRegistry::default();
+        register_praxis_tools(&config, &mut registry);
+
+        let tool = registry.get("grep").unwrap();
+        let ctx = arcan_core::runtime::ToolContext {
+            run_id: "test-run".into(),
+            session_id: "test-session".into(),
+            iteration: 1,
+        };
+        let call = arcan_core::protocol::ToolCall {
+            call_id: "call-5".into(),
+            tool_name: "grep".into(),
+            input: json!({"pattern": "println"}),
+        };
+
+        let result = tool.execute(&call, &ctx).unwrap();
+        assert!(!result.is_error);
+        assert_eq!(result.output["count"], 1);
+    }
+
+    #[test]
+    fn workspace_boundary_enforced_through_bridge() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(&dir);
+        let mut registry = ToolRegistry::default();
+        register_praxis_tools(&config, &mut registry);
+
+        let tool = registry.get("read_file").unwrap();
+        let ctx = arcan_core::runtime::ToolContext {
+            run_id: "test-run".into(),
+            session_id: "test-session".into(),
+            iteration: 1,
+        };
+        let call = arcan_core::protocol::ToolCall {
+            call_id: "call-6".into(),
+            tool_name: "read_file".into(),
+            input: json!({"path": "/etc/passwd"}),
+        };
+
+        // Should fail — path is outside workspace
+        let result = tool.execute(&call, &ctx);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn shell_disabled_rejects_bash() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config(&dir).with_shell_disabled();
+        let mut registry = ToolRegistry::default();
+        register_praxis_tools(&config, &mut registry);
+
+        let tool = registry.get("bash").unwrap();
+        let ctx = arcan_core::runtime::ToolContext {
+            run_id: "test-run".into(),
+            session_id: "test-session".into(),
+            iteration: 1,
+        };
+        let call = arcan_core::protocol::ToolCall {
+            call_id: "call-7".into(),
+            tool_name: "bash".into(),
+            input: json!({"command": "echo should-not-run"}),
+        };
+
+        // Should fail — shell is disabled
+        let result = tool.execute(&call, &ctx);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn memory_tools_through_bridge_work() {
+        let dir = TempDir::new().unwrap();
+        let config = make_config_with_memory(&dir);
+        let mut registry = ToolRegistry::default();
+        register_praxis_tools(&config, &mut registry);
+
+        let ctx = arcan_core::runtime::ToolContext {
+            run_id: "test-run".into(),
+            session_id: "test-session".into(),
+            iteration: 1,
+        };
+
+        // Write memory
+        let write_tool = registry.get("write_memory").unwrap();
+        let call = arcan_core::protocol::ToolCall {
+            call_id: "call-8".into(),
+            tool_name: "write_memory".into(),
+            input: json!({"key": "bridge-test", "content": "# Memory\nBridge works!"}),
+        };
+        let result = write_tool.execute(&call, &ctx).unwrap();
+        assert!(!result.is_error);
+        assert_eq!(result.output["success"], true);
+
+        // Read memory
+        let read_tool = registry.get("read_memory").unwrap();
+        let call = arcan_core::protocol::ToolCall {
+            call_id: "call-9".into(),
+            tool_name: "read_memory".into(),
+            input: json!({"key": "bridge-test"}),
+        };
+        let result = read_tool.execute(&call, &ctx).unwrap();
+        assert!(!result.is_error);
+        assert_eq!(result.output["exists"], true);
+        assert!(
+            result.output["content"]
+                .as_str()
+                .unwrap()
+                .contains("Bridge works!")
+        );
+    }
+
+    #[test]
+    fn edit_file_through_bridge_works() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("edit-me.txt"), "line1\nline2\nline3").unwrap();
+
+        let config = make_config(&dir);
+        let mut registry = ToolRegistry::default();
+        register_praxis_tools(&config, &mut registry);
+
+        // First, read the file to get hash tags
+        let read_tool = registry.get("read_file").unwrap();
+        let ctx = arcan_core::runtime::ToolContext {
+            run_id: "test-run".into(),
+            session_id: "test-session".into(),
+            iteration: 1,
+        };
+        let call = arcan_core::protocol::ToolCall {
+            call_id: "call-10".into(),
+            tool_name: "read_file".into(),
+            input: json!({"path": "edit-me.txt"}),
+        };
+        let result = read_tool.execute(&call, &ctx).unwrap();
+        let content = result.output["content"].as_str().unwrap();
+
+        // Extract the hash tag for line 2 from the formatted output
+        // Format is: "   2 <hash> | line2"
+        let line2_tag = content
+            .lines()
+            .find(|l| l.contains("line2"))
+            .unwrap()
+            .split_whitespace()
+            .nth(1) // the hash tag
+            .unwrap();
+
+        // Now edit using the hash tag
+        let edit_tool = registry.get("edit_file").unwrap();
+        let call = arcan_core::protocol::ToolCall {
+            call_id: "call-11".into(),
+            tool_name: "edit_file".into(),
+            input: json!({
+                "path": "edit-me.txt",
+                "ops": [
+                    { "op": "replace_line", "tag": line2_tag, "new_text": "LINE_TWO_REPLACED" }
+                ]
+            }),
+        };
+        let result = edit_tool.execute(&call, &ctx).unwrap();
+        assert!(!result.is_error);
+        assert_eq!(result.output["success"], true);
+
+        // Verify the file was actually edited
+        let final_content = std::fs::read_to_string(dir.path().join("edit-me.txt")).unwrap();
+        assert!(final_content.contains("LINE_TWO_REPLACED"));
+        assert!(!final_content.contains("line2"));
+    }
+}

--- a/crates/arcan/Cargo.toml
+++ b/crates/arcan/Cargo.toml
@@ -22,10 +22,12 @@ workspace = true
 default = ["console"]
 console = ["dep:arcan-console"]
 spaces = ["dep:arcan-spaces", "arcan-spaces/spacetimedb"]
+praxis = ["dep:arcan-praxis"]
 
 [dependencies]
 arcan-console = { path = "../arcan-console", version = "0.2.1", optional = true }
 arcan-spaces = { path = "../arcan-spaces", version = "0.2.1", optional = true }
+arcan-praxis = { path = "../arcan-praxis", version = "0.2.1", optional = true }
 arcan-core = { path = "../arcan-core", version = "0.2.1" }
 arcan-aios-adapters = { path = "../arcan-aios-adapters", version = "0.2.1" }
 arcan-harness = { path = "../arcan-harness", version = "0.2.1" }


### PR DESCRIPTION
## Summary

- Introduces the `arcan-praxis` crate that configures and registers the full suite of Praxis canonical tools into Arcan's `ToolRegistry`
- Uses `PraxisConfig` builder to capture workspace root, sandbox constraints (FsPolicy/SandboxPolicy), and optional memory directory
- `register_praxis_tools()` constructs all tools (ReadFile, WriteFile, EditFile, Glob, Grep, Bash, ReadMemory, WriteMemory), wraps them through `PraxisToolBridge`, and registers them in one call
- Feature-gated in the `arcan` binary crate (`features = ["praxis"]`) for opt-in adoption without affecting existing `arcan-harness` usage

## Design

This crate is intentionally thin glue:
1. `PraxisConfig` captures workspace root + sandbox constraints
2. Constructs Praxis tool instances with proper `FsPolicy` and `SandboxPolicy`
3. Wraps each tool in `PraxisToolBridge` (from arcan-harness) to satisfy `arcan_core::runtime::Tool`
4. Registers them all into an Arcan `ToolRegistry`

The actual tool implementations remain in `praxis-tools`. The type adapter remains in `arcan-harness`. This crate is the integration layer.

## Test plan

- [x] 18 tests in `arcan-praxis` covering:
  - Config defaults and builder methods
  - FsPolicy/SandboxPolicy construction from config
  - Core tool registration (7 tools without memory)
  - Memory tool registration (9 tools with memory)
  - End-to-end tool dispatch: read_file, write_file, edit_file, glob, grep, bash, memory
  - Workspace boundary enforcement (path outside workspace rejected)
  - Shell policy enforcement (disabled shell rejects bash)
- [x] Full workspace `cargo check` and `cargo test` pass (0 failures)
- [x] `cargo clippy` clean (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)