### PR TITLE
feat: add Haima payment middleware for x402 tool responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +240,10 @@ dependencies = [
  "async-trait",
  "autonomic-controller",
  "autonomic-core",
+ "haima-core",
+ "haima-lago",
+ "haima-wallet",
+ "haima-x402",
  "lago-core",
  "reqwest",
  "serde",
@@ -643,10 +657,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -750,6 +776,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +811,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -834,6 +895,12 @@ dependencies = [
  "once_cell",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -1004,12 +1071,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1082,6 +1162,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,7 +1209,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1176,10 +1268,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1247,6 +1372,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -1422,6 +1557,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1456,6 +1592,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1619,74 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "haima-core"
+version = "0.1.0"
+dependencies = [
+ "aios-protocol",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "haima-lago"
+version = "0.1.0"
+dependencies = [
+ "aios-protocol",
+ "chrono",
+ "haima-core",
+ "lago-core",
+ "lago-journal",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "haima-wallet"
+version = "0.1.0"
+dependencies = [
+ "aios-protocol",
+ "async-trait",
+ "base64",
+ "chacha20poly1305",
+ "haima-core",
+ "hex",
+ "k256",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror 2.0.18",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "haima-x402"
+version = "0.1.0"
+dependencies = [
+ "aios-protocol",
+ "async-trait",
+ "base64",
+ "haima-core",
+ "haima-wallet",
+ "hex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1508,6 +1723,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1817,6 +2041,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +2188,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,6 +2210,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2468,6 +2724,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,10 +3071,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3279,6 +3562,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rig-core"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3539,6 +3832,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,6 +3994,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3730,6 +4047,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3786,6 +4113,16 @@ checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -4539,6 +4876,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4560,6 +4907,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -5305,6 +5653,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,12 @@ praxis-mcp = { path = "../praxis/crates/praxis-mcp", version = "0.1.0" }
 autonomic-core = { path = "../autonomic/crates/autonomic-core", version = "0.1.0" }
 autonomic-controller = { path = "../autonomic/crates/autonomic-controller", version = "0.1.0" }
 
+# Haima agentic finance engine (x402 payments, wallet, policy)
+haima-core = { path = "../haima/crates/haima-core", version = "0.1.0" }
+haima-x402 = { path = "../haima/crates/haima-x402", version = "0.1.0" }
+haima-wallet = { path = "../haima/crates/haima-wallet", version = "0.1.0" }
+haima-lago = { path = "../haima/crates/haima-lago", version = "0.1.0" }
+
 # Lago persistence layer (path deps for local development)
 lago-api = { path = "../lago/crates/lago-api", version = "0.2.1" }
 lago-core = { path = "../lago/crates/lago-core", version = "0.2.1" }

--- a/crates/arcan-aios-adapters/Cargo.toml
+++ b/crates/arcan-aios-adapters/Cargo.toml
@@ -11,6 +11,10 @@ categories.workspace = true
 description = "Arcan adapters implementing aiOS protocol ports"
 readme = "../../README.md"
 
+[features]
+default = []
+haima = ["dep:haima-core", "dep:haima-x402", "dep:haima-wallet", "dep:haima-lago"]
+
 [lints]
 workspace = true
 
@@ -21,6 +25,12 @@ aios-policy = { workspace = true }
 autonomic-core = { workspace = true }
 autonomic-controller = { workspace = true }
 lago-core = { workspace = true }
+
+# Haima finance engine (optional, feature-gated)
+haima-core = { workspace = true, optional = true }
+haima-x402 = { workspace = true, optional = true }
+haima-wallet = { workspace = true, optional = true }
+haima-lago = { workspace = true, optional = true }
 
 anyhow.workspace = true
 async-trait.workspace = true
@@ -34,3 +44,8 @@ vigil.workspace = true
 
 [dev-dependencies]
 wiremock = "0.6"
+# Haima dependencies needed for tests (feature-gated tests require the types)
+haima-core = { workspace = true }
+haima-x402 = { workspace = true }
+haima-wallet = { workspace = true }
+haima-lago = { workspace = true }

--- a/crates/arcan-aios-adapters/src/haima_middleware.rs
+++ b/crates/arcan-aios-adapters/src/haima_middleware.rs
@@ -1,0 +1,516 @@
+//! Haima payment middleware — intercepts HTTP 402 tool results and invokes
+//! the x402 payment flow.
+//!
+//! [`HaimaPaymentMiddleware`] implements the [`Middleware`] trait as a
+//! **post-tool-call** interceptor. When a tool result indicates an HTTP 402
+//! response with a `payment-required` header, the middleware:
+//!
+//! 1. Invokes [`X402Client::handle_402`] to parse terms, evaluate policy, and
+//!    optionally sign the payment.
+//! 2. Publishes the appropriate [`FinanceEventKind`] to the Lago journal via
+//!    [`FinancePublisher`].
+//! 3. Logs the outcome (approved / requires-approval / denied).
+//!
+//! The middleware does **not** retry the tool call — that is the orchestrator's
+//! responsibility. It only processes the payment side-channel so that the
+//! financial state is updated and events are emitted.
+
+use std::sync::Arc;
+
+use arcan_core::runtime::Middleware;
+use arcan_core::{CoreError, ToolContext, ToolResult};
+use haima_core::event::FinanceEventKind;
+use haima_core::payment::PaymentDecision;
+use haima_lago::publisher::FinancePublisher;
+use haima_x402::client::X402Client;
+use tracing::{debug, info, warn};
+
+// ---------------------------------------------------------------------------
+// Constants for detecting 402 in tool output
+// ---------------------------------------------------------------------------
+
+/// JSON field name that tools use to report HTTP status codes.
+const STATUS_CODE_FIELD: &str = "status_code";
+/// JSON field name for the `payment-required` header value from 402 responses.
+const PAYMENT_REQUIRED_HEADER_FIELD: &str = "payment_required_header";
+/// JSON field name for the resource URL that returned 402.
+const RESOURCE_URL_FIELD: &str = "resource_url";
+
+/// HTTP 402 status code.
+const HTTP_402: u64 = 402;
+
+// ---------------------------------------------------------------------------
+// HaimaPaymentMiddleware
+// ---------------------------------------------------------------------------
+
+/// Post-tool-call middleware that handles HTTP 402 payment flows.
+///
+/// When a tool result's `output` JSON contains:
+/// - `status_code: 402`
+/// - `payment_required_header: "<base64-encoded header>"`
+/// - `resource_url: "<url>"`
+///
+/// the middleware invokes the x402 client to evaluate and optionally sign the
+/// payment, then emits the corresponding finance event.
+pub struct HaimaPaymentMiddleware {
+    x402_client: Arc<X402Client>,
+    publisher: Arc<FinancePublisher>,
+}
+
+impl HaimaPaymentMiddleware {
+    /// Create a new payment middleware.
+    pub fn new(x402_client: Arc<X402Client>, publisher: Arc<FinancePublisher>) -> Self {
+        Self {
+            x402_client,
+            publisher,
+        }
+    }
+}
+
+impl Middleware for HaimaPaymentMiddleware {
+    fn post_tool_call(&self, context: &ToolContext, result: &ToolResult) -> Result<(), CoreError> {
+        // Check if this tool result indicates an HTTP 402.
+        let Some(info) = extract_402_info(result) else {
+            return Ok(());
+        };
+
+        info!(
+            tool = %result.tool_name,
+            resource_url = %info.resource_url,
+            session_id = %context.session_id,
+            "detected HTTP 402 in tool result, invoking x402 payment flow"
+        );
+
+        // Spawn the async payment handling on the current runtime.
+        // The middleware trait is sync, so we bridge to async via spawn_blocking
+        // inverse: we spawn an async task and block on it.
+        let x402_client = Arc::clone(&self.x402_client);
+        let publisher = Arc::clone(&self.publisher);
+        let resource_url = info.resource_url.clone();
+        let payment_header = info.payment_required_header.clone();
+        let session_id = context.session_id.clone();
+
+        // Use tokio::task::block_in_place to allow blocking within an async
+        // context, then use Handle::current() to run the async work.
+        tokio::task::block_in_place(|| {
+            let handle = tokio::runtime::Handle::current();
+            handle.block_on(async move {
+                handle_payment_flow(
+                    &x402_client,
+                    &publisher,
+                    &resource_url,
+                    &payment_header,
+                    &session_id,
+                )
+                .await;
+            });
+        });
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 402 detection helpers
+// ---------------------------------------------------------------------------
+
+/// Information extracted from a tool result that indicates an HTTP 402.
+struct Http402Info {
+    resource_url: String,
+    payment_required_header: String,
+}
+
+/// Try to extract 402 payment information from a tool result.
+///
+/// Returns `Some(Http402Info)` if the tool result's `output` JSON contains
+/// the expected fields indicating an HTTP 402 response.
+fn extract_402_info(result: &ToolResult) -> Option<Http402Info> {
+    let output = &result.output;
+
+    // Check for status_code == 402
+    let status_code = output.get(STATUS_CODE_FIELD)?.as_u64()?;
+    if status_code != HTTP_402 {
+        return None;
+    }
+
+    // Extract the payment-required header value
+    let payment_required_header = output
+        .get(PAYMENT_REQUIRED_HEADER_FIELD)?
+        .as_str()?
+        .to_owned();
+
+    // Extract the resource URL (with fallback)
+    let resource_url = output
+        .get(RESOURCE_URL_FIELD)
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_owned();
+
+    Some(Http402Info {
+        resource_url,
+        payment_required_header,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Payment flow
+// ---------------------------------------------------------------------------
+
+/// Process the x402 payment flow and emit finance events.
+async fn handle_payment_flow(
+    x402_client: &X402Client,
+    publisher: &FinancePublisher,
+    resource_url: &str,
+    payment_required_header: &str,
+    session_id: &str,
+) {
+    // Step 1: Invoke x402 client to parse, evaluate, and optionally sign.
+    let handle_result = match x402_client
+        .handle_402(resource_url, payment_required_header)
+        .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            warn!(
+                error = %e,
+                resource_url,
+                session_id,
+                "x402 handle_402 failed"
+            );
+            // Emit a payment-failed event for observability.
+            let failed_event = FinanceEventKind::PaymentFailed {
+                resource_url: resource_url.to_owned(),
+                amount_micro_credits: 0,
+                reason: format!("x402 protocol error: {e}"),
+            };
+            if let Err(pub_err) = publisher.publish(&failed_event).await {
+                warn!(error = %pub_err, "failed to publish payment_failed event");
+            }
+            return;
+        }
+    };
+
+    let requirement = &handle_result.requirement;
+    let amount_str = &requirement.amount;
+    let micro_credits = amount_str.parse::<i64>().unwrap_or(0);
+
+    // Step 2: Emit events based on the decision.
+    match &handle_result.decision {
+        PaymentDecision::Approved {
+            payer,
+            micro_credit_cost,
+            reason,
+        } => {
+            info!(
+                resource_url,
+                micro_credit_cost,
+                payer = %payer,
+                reason,
+                session_id,
+                "payment auto-approved and signed"
+            );
+
+            // Emit PaymentRequested
+            let requested_event = FinanceEventKind::PaymentRequested {
+                resource_url: resource_url.to_owned(),
+                amount_micro_credits: *micro_credit_cost,
+                token: requirement.token.clone(),
+                chain: requirement.network.clone(),
+            };
+            if let Err(e) = publisher.publish(&requested_event).await {
+                warn!(error = %e, "failed to publish payment_requested event");
+            }
+
+            // Emit PaymentAuthorized
+            let authorized_event = FinanceEventKind::PaymentAuthorized {
+                resource_url: resource_url.to_owned(),
+                amount_micro_credits: *micro_credit_cost,
+                payer_address: payer.address.clone(),
+                recipient_address: requirement.recipient.clone(),
+            };
+            if let Err(e) = publisher.publish(&authorized_event).await {
+                warn!(error = %e, "failed to publish payment_authorized event");
+            }
+        }
+
+        PaymentDecision::RequiresApproval {
+            micro_credit_cost,
+            reason,
+        } => {
+            info!(
+                resource_url,
+                micro_credit_cost, reason, session_id, "payment requires human approval"
+            );
+
+            // Emit PaymentRequested (the request happened, approval pending)
+            let requested_event = FinanceEventKind::PaymentRequested {
+                resource_url: resource_url.to_owned(),
+                amount_micro_credits: *micro_credit_cost,
+                token: requirement.token.clone(),
+                chain: requirement.network.clone(),
+            };
+            if let Err(e) = publisher.publish(&requested_event).await {
+                warn!(error = %e, "failed to publish payment_requested event");
+            }
+
+            // Note: The ApprovalRequested flow is handled by the orchestrator
+            // via Arcan's ApprovalPort. We only record the payment request here.
+        }
+
+        PaymentDecision::Denied { reason } => {
+            warn!(
+                resource_url,
+                reason, micro_credits, session_id, "payment denied by policy"
+            );
+
+            // Emit PaymentFailed with the denial reason
+            let denied_event = FinanceEventKind::PaymentFailed {
+                resource_url: resource_url.to_owned(),
+                amount_micro_credits: micro_credits,
+                reason: format!("policy denied: {reason}"),
+            };
+            if let Err(e) = publisher.publish(&denied_event).await {
+                warn!(error = %e, "failed to publish payment_failed event");
+            }
+        }
+    }
+
+    debug!(
+        resource_url,
+        session_id,
+        decision = ?handle_result.decision,
+        "payment flow complete"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // -- extract_402_info tests --
+
+    fn make_402_result(amount: &str) -> ToolResult {
+        ToolResult {
+            call_id: "call-1".into(),
+            tool_name: "http_request".into(),
+            output: json!({
+                "status_code": 402,
+                "payment_required_header": amount,
+                "resource_url": "https://api.example.com/data"
+            }),
+            content: None,
+            is_error: true,
+            state_patch: None,
+        }
+    }
+
+    fn make_ok_result() -> ToolResult {
+        ToolResult {
+            call_id: "call-2".into(),
+            tool_name: "http_request".into(),
+            output: json!({
+                "status_code": 200,
+                "body": "success"
+            }),
+            content: None,
+            is_error: false,
+            state_patch: None,
+        }
+    }
+
+    fn make_error_result() -> ToolResult {
+        ToolResult {
+            call_id: "call-3".into(),
+            tool_name: "read_file".into(),
+            output: json!({
+                "error": "file not found"
+            }),
+            content: None,
+            is_error: true,
+            state_patch: None,
+        }
+    }
+
+    fn make_402_no_header() -> ToolResult {
+        ToolResult {
+            call_id: "call-4".into(),
+            tool_name: "http_request".into(),
+            output: json!({
+                "status_code": 402,
+                "resource_url": "https://api.example.com/data"
+            }),
+            content: None,
+            is_error: true,
+            state_patch: None,
+        }
+    }
+
+    #[test]
+    fn extract_402_info_from_valid_result() {
+        let result = make_402_result("dGVzdC1oZWFkZXI=");
+        let info = extract_402_info(&result);
+        assert!(info.is_some());
+        let info = info.unwrap();
+        assert_eq!(info.resource_url, "https://api.example.com/data");
+        assert_eq!(info.payment_required_header, "dGVzdC1oZWFkZXI=");
+    }
+
+    #[test]
+    fn extract_402_info_returns_none_for_200() {
+        let result = make_ok_result();
+        assert!(extract_402_info(&result).is_none());
+    }
+
+    #[test]
+    fn extract_402_info_returns_none_for_non_http() {
+        let result = make_error_result();
+        assert!(extract_402_info(&result).is_none());
+    }
+
+    #[test]
+    fn extract_402_info_returns_none_without_header() {
+        let result = make_402_no_header();
+        assert!(extract_402_info(&result).is_none());
+    }
+
+    // -- Middleware integration tests (using real X402Client + mock publisher) --
+
+    use haima_core::policy::PaymentPolicy;
+    use haima_core::wallet::ChainId;
+    use haima_wallet::LocalSigner;
+    use haima_x402::client::X402Client;
+    use haima_x402::facilitator::{Facilitator, FacilitatorConfig};
+    use haima_x402::header::{PaymentRequiredHeader, SchemeRequirement, encode_payment_required};
+
+    fn test_middleware() -> (HaimaPaymentMiddleware, Arc<FinancePublisher>) {
+        let signer = LocalSigner::generate(ChainId::base()).unwrap();
+        let facilitator = Facilitator::new(FacilitatorConfig::default());
+        let x402_client = Arc::new(X402Client::new(
+            Arc::new(signer),
+            facilitator,
+            PaymentPolicy::default(),
+        ));
+        let publisher = Arc::new(FinancePublisher::new(false)); // Disabled for tests
+        let middleware =
+            HaimaPaymentMiddleware::new(Arc::clone(&x402_client), Arc::clone(&publisher));
+        (middleware, publisher)
+    }
+
+    fn sample_payment_required_header(amount: &str) -> String {
+        let header = PaymentRequiredHeader {
+            schemes: vec![SchemeRequirement {
+                scheme: "exact".into(),
+                network: "eip155:8453".into(),
+                token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".into(),
+                amount: amount.into(),
+                recipient: "0xrecipient".into(),
+                facilitator: "https://x402.org/facilitator".into(),
+            }],
+            version: "v2".into(),
+        };
+        encode_payment_required(&header).unwrap()
+    }
+
+    fn test_context() -> ToolContext {
+        ToolContext {
+            run_id: "run-1".into(),
+            session_id: "session-1".into(),
+            iteration: 1,
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn middleware_ignores_non_402_results() {
+        let (middleware, _) = test_middleware();
+        let ctx = test_context();
+
+        // 200 response - should pass through
+        let result = make_ok_result();
+        let outcome = middleware.post_tool_call(&ctx, &result);
+        assert!(outcome.is_ok());
+
+        // Non-HTTP error - should pass through
+        let result = make_error_result();
+        let outcome = middleware.post_tool_call(&ctx, &result);
+        assert!(outcome.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn middleware_handles_402_auto_approve() {
+        let (middleware, _publisher) = test_middleware();
+        let ctx = test_context();
+
+        // 50 micro-credits is below auto-approve cap of 100
+        let encoded_header = sample_payment_required_header("50");
+        let result = ToolResult {
+            call_id: "call-1".into(),
+            tool_name: "http_request".into(),
+            output: json!({
+                "status_code": 402,
+                "payment_required_header": encoded_header,
+                "resource_url": "https://api.example.com/paid-data"
+            }),
+            content: None,
+            is_error: true,
+            state_patch: None,
+        };
+
+        // Should not error — the middleware processes the payment flow internally
+        let outcome = middleware.post_tool_call(&ctx, &result);
+        assert!(outcome.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn middleware_handles_402_denied() {
+        let (middleware, _publisher) = test_middleware();
+        let ctx = test_context();
+
+        // 2_000_000 exceeds hard cap of 1_000_000 — will be denied
+        let encoded_header = sample_payment_required_header("2000000");
+        let result = ToolResult {
+            call_id: "call-1".into(),
+            tool_name: "http_request".into(),
+            output: json!({
+                "status_code": 402,
+                "payment_required_header": encoded_header,
+                "resource_url": "https://api.example.com/expensive"
+            }),
+            content: None,
+            is_error: true,
+            state_patch: None,
+        };
+
+        // Should not error — denial is a valid outcome
+        let outcome = middleware.post_tool_call(&ctx, &result);
+        assert!(outcome.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn middleware_handles_invalid_payment_header() {
+        let (middleware, _publisher) = test_middleware();
+        let ctx = test_context();
+
+        // Invalid base64 header — x402 client will return an error
+        let result = ToolResult {
+            call_id: "call-1".into(),
+            tool_name: "http_request".into(),
+            output: json!({
+                "status_code": 402,
+                "payment_required_header": "not-valid-base64!!!",
+                "resource_url": "https://api.example.com/broken"
+            }),
+            content: None,
+            is_error: true,
+            state_patch: None,
+        };
+
+        // Should not error — the middleware logs and emits PaymentFailed
+        let outcome = middleware.post_tool_call(&ctx, &result);
+        assert!(outcome.is_ok());
+    }
+}

--- a/crates/arcan-aios-adapters/src/lib.rs
+++ b/crates/arcan-aios-adapters/src/lib.rs
@@ -2,6 +2,8 @@ pub mod approval;
 pub mod autonomic;
 pub mod embedded_autonomic;
 pub mod gating_middleware;
+#[cfg(feature = "haima")]
+pub mod haima_middleware;
 pub mod policy;
 pub mod provider;
 pub mod tools;
@@ -10,6 +12,8 @@ pub use approval::ArcanApprovalAdapter;
 pub use autonomic::{AutonomicPolicyAdapter, EconomicGateHandle, GatingProfileHandle};
 pub use embedded_autonomic::EmbeddedAutonomicController;
 pub use gating_middleware::{AutonomicGatingMiddleware, AutonomicGatingState};
+#[cfg(feature = "haima")]
+pub use haima_middleware::HaimaPaymentMiddleware;
 pub use policy::ArcanPolicyAdapter;
 pub use provider::{ArcanProviderAdapter, StreamingSenderHandle};
 


### PR DESCRIPTION
## Summary

- Add `HaimaPaymentMiddleware` implementing `Middleware::post_tool_call` in `arcan-aios-adapters`
- When a tool result contains HTTP 402 + `payment_required_header`, invokes `X402Client::handle_402()` to evaluate payment policy and optionally sign
- Emits `FinanceEventKind` events (`PaymentRequested`, `PaymentAuthorized`, `PaymentFailed`) via `FinancePublisher` for Lago journal persistence
- All Haima dependencies are feature-gated under `#[cfg(feature = "haima")]` with optional deps (`haima-core`, `haima-x402`, `haima-wallet`, `haima-lago`)
- Handles all three payment decision paths: auto-approve, requires-approval, and denied

## Files changed

- `Cargo.toml` — Add workspace deps for haima-core, haima-x402, haima-wallet, haima-lago
- `crates/arcan-aios-adapters/Cargo.toml` — Add `haima` feature with optional + dev deps
- `crates/arcan-aios-adapters/src/haima_middleware.rs` — New middleware implementation (280 LOC + 200 LOC tests)
- `crates/arcan-aios-adapters/src/lib.rs` — Feature-gated module + re-export

## Test plan

- [x] 4 unit tests for `extract_402_info` (valid 402, 200 response, non-HTTP error, missing header)
- [x] 3 integration tests for middleware (auto-approve path, deny path, invalid header error handling)
- [x] `cargo check` without `haima` feature — compiles cleanly (feature gate works)
- [x] `cargo check --workspace` — full workspace compiles
- [x] `cargo test -p arcan-aios-adapters --features haima` — 36/36 pass
- [x] `cargo test --workspace` — all workspace tests pass
- [x] `cargo clippy -p arcan-aios-adapters --features haima` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)