### PR TITLE
feat: auto-sync skills on daemon startup

### DIFF
--- a/crates/arcan/src/main.rs
+++ b/crates/arcan/src/main.rs
@@ -422,6 +422,14 @@ fn run_serve(
         let skills_dir = data_dir.join("skills");
         std::fs::create_dir_all(&skills_dir).ok();
 
+        // Auto-sync: symlink skills from ~/.agents/skills/ and .agents/skills/ into .arcan/skills/
+        // so that `npx skills add` installs are immediately visible to Arcan.
+        match skills::sync_skills_to_arcan(data_dir) {
+            Ok(0) => {}
+            Ok(n) => tracing::info!(synced = n, "auto-synced skills into .arcan/skills/"),
+            Err(e) => tracing::debug!(error = %e, "skill auto-sync skipped"),
+        }
+
         match skills::discover_skills(
             &resolved.skill_dirs,
             data_dir,


### PR DESCRIPTION
## Summary
- Runs `sync_skills_to_arcan()` automatically during `arcan serve` startup
- Skills installed via `npx skills add -g` are immediately symlinked into `.arcan/skills/`
- No manual `arcan skills sync` required after installing new skills
- Non-blocking: sync errors are logged at debug level, don't prevent startup

## Context
The `skills` CLI (`npx skills add`) installs to `~/.agents/skills/`. Arcan discovers skills from three dirs: `.arcan/skills/`, `.agents/skills/`, `~/.agents/skills/`. While `~/.agents/skills/` is already scanned directly, the auto-sync ensures `.arcan/skills/` symlinks are kept in sync for consistency and for the `arcan skills list` cache.

## Test plan
- [x] `cargo test -p arcan -- skills` — 7 tests pass
- [x] `cargo clippy --workspace` — zero warnings
- [x] Verified: `arcan serve` logs `auto-synced skills into .arcan/skills/` when new skills found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Serve mode now automatically synchronizes your skills directory before discovering available skills, ensuring your skills library is always current and ready for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->