### PR TITLE
feat(sandbox): BubblewrapProvider — local SandboxProvider via tokio::process (BRO-245)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcan-sandbox"
+version = "0.2.1"
+dependencies = [
+ "aios-protocol",
+ "anyhow",
+ "async-trait",
+ "bitflags 2.10.0",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "arcan-spaces"
 version = "0.2.1"
 dependencies = [
@@ -811,6 +826,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "blake3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcan-provider-vercel"
+version = "0.2.1"
+dependencies = [
+ "anyhow",
+ "arcan-sandbox",
+ "async-trait",
+ "chrono",
+ "mockito",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "arcan-sandbox"
 version = "0.2.1"
 dependencies = [
@@ -1067,6 +1085,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "compact_str"
@@ -2882,6 +2909,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.2",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "nanoid"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,6 +3599,8 @@ name = "praxis-tools"
 version = "0.1.0"
 dependencies = [
  "aios-protocol",
+ "arcan-sandbox",
+ "async-trait",
  "blake3",
  "glob",
  "praxis-core",
@@ -3554,6 +3608,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcan-provider-bubblewrap"
+version = "0.2.1"
+dependencies = [
+ "anyhow",
+ "arcan-sandbox",
+ "async-trait",
+ "chrono",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "arcan-provider-local"
+version = "0.2.1"
+dependencies = [
+ "anyhow",
+ "arcan-sandbox",
+ "async-trait",
+ "chrono",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "arcan-sandbox"
 version = "0.2.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 # workspace — arcan agent runtime (cache-bust: 2026-03-25)
 [workspace]
 members = [
+  "crates/arcan-sandbox",
   "crates/arcan-anima",
   "crates/arcan-console",
   "crates/arcan-core",
@@ -63,6 +64,7 @@ categories = ["command-line-utilities", "web-programming"]
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1"
+bitflags = { version = "2", features = ["serde"] }
 axum = { version = "0.8", features = ["macros"] }
 blake3 = "1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -141,3 +143,6 @@ anima-lago = { path = "../anima/crates/anima-lago", version = "0.1.0" }
 
 # Observability
 life-vigil = { version = "0.1.0", path = "../vigil" }
+
+# Arcan sandbox provider abstraction
+arcan-sandbox = { path = "crates/arcan-sandbox", version = "0.2.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 [workspace]
 members = [
   "crates/arcan-sandbox",
+  "crates/arcan-provider-bubblewrap",
+  "crates/arcan-provider-local",
   "crates/arcan-anima",
   "crates/arcan-console",
   "crates/arcan-core",
@@ -146,3 +148,5 @@ life-vigil = { version = "0.1.0", path = "../vigil" }
 
 # Arcan sandbox provider abstraction
 arcan-sandbox = { path = "crates/arcan-sandbox", version = "0.2.1" }
+arcan-provider-bubblewrap = { path = "crates/arcan-provider-bubblewrap", version = "0.2.1" }
+arcan-provider-vercel = { path = "crates/arcan-provider-vercel", version = "0.2.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 [workspace]
 members = [
   "crates/arcan-sandbox",
+  "crates/arcan-provider-vercel",
   "crates/arcan-provider-bubblewrap",
   "crates/arcan-provider-local",
   "crates/arcan-anima",

--- a/crates/arcan-core/src/queue.rs
+++ b/crates/arcan-core/src/queue.rs
@@ -1,0 +1,615 @@
+//! Message queue and steering semantics for concurrent message handling (Phase 2.5).
+//!
+//! Enables safe preemption at tool boundaries, message queuing during active runs,
+//! and priority-based drain ordering: interrupt > steer > followup > collect.
+
+use aios_protocol::SteeringMode;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+// ─── Configuration ───────────────────────────────────────────────
+
+/// Configuration for the message queue.
+#[derive(Debug, Clone)]
+pub struct QueueConfig {
+    /// Maximum number of pending messages (default: 10).
+    pub max_queue_depth: usize,
+    /// Max time to wait for a tool boundary when steering (default: 30s).
+    pub steer_timeout: Duration,
+    /// Batch collect messages within this window (default: 2s).
+    pub collect_coalesce_window: Duration,
+}
+
+impl Default for QueueConfig {
+    fn default() -> Self {
+        Self {
+            max_queue_depth: 10,
+            steer_timeout: Duration::from_secs(30),
+            collect_coalesce_window: Duration::from_secs(2),
+        }
+    }
+}
+
+// ─── Queued message ──────────────────────────────────────────────
+
+/// A message waiting in the queue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueuedMessage {
+    /// Unique identifier for this queued message.
+    pub id: String,
+    /// How this message should interact with the active run.
+    pub mode: SteeringMode,
+    /// The message content (user text, instruction, etc.).
+    pub content: String,
+    /// When the message was queued (not serialized — set on enqueue).
+    #[serde(skip)]
+    pub queued_at: Option<Instant>,
+}
+
+// ─── Steering action ─────────────────────────────────────────────
+
+/// Action to take at a tool boundary based on queue state.
+#[derive(Debug, Clone)]
+pub enum SteeringAction {
+    /// Continue current run (no preemption).
+    Continue,
+    /// Inject a new message into the current run context.
+    InjectMessage(String),
+    /// Complete current run early and start new run with queued message.
+    CompleteAndSwitch(QueuedMessage),
+    /// Abort current run (emergency interrupt).
+    Abort { reason: String },
+}
+
+// ─── Preemption check trait ──────────────────────────────────────
+
+/// Trait for checking preemption at tool boundaries.
+///
+/// Called after each tool execution completes. Implementors inspect the
+/// queue state and decide whether the run should continue or be redirected.
+pub trait PreemptionCheck: Send + Sync {
+    /// Called after each tool execution completes.
+    /// Returns a `SteeringAction` indicating what should happen next.
+    fn check_preemption(&self) -> SteeringAction;
+}
+
+// ─── Queue status ────────────────────────────────────────────────
+
+/// Snapshot of the queue state for API responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueStatus {
+    pub depth: usize,
+    pub pending: Vec<QueuedMessage>,
+    pub has_active_run: bool,
+    pub oldest_message_age_ms: Option<u64>,
+}
+
+// ─── Queue error ─────────────────────────────────────────────────
+
+/// Errors from queue operations.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum QueueError {
+    #[error("queue is full (depth: {depth}, max: {max})")]
+    QueueFull { depth: usize, max: usize },
+    #[error("message not found: {id}")]
+    NotFound { id: String },
+}
+
+// ─── Message queue ───────────────────────────────────────────────
+
+/// Thread-safe message queue with steering semantics.
+///
+/// Messages are enqueued with a [`SteeringMode`] that determines how they
+/// interact with an active run. The queue supports priority-based ordering
+/// and safe preemption at tool boundaries.
+pub struct MessageQueue {
+    inner: Arc<Mutex<QueueInner>>,
+    config: QueueConfig,
+}
+
+struct QueueInner {
+    pending: VecDeque<QueuedMessage>,
+    has_active_run: bool,
+}
+
+impl MessageQueue {
+    /// Create a new message queue with the given configuration.
+    pub fn new(config: QueueConfig) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(QueueInner {
+                pending: VecDeque::new(),
+                has_active_run: false,
+            })),
+            config,
+        }
+    }
+
+    /// Enqueue a message. Returns error if queue is full.
+    pub fn enqueue(&self, message: QueuedMessage) -> Result<(), QueueError> {
+        let mut inner = self.inner.lock().expect("queue lock poisoned");
+        if inner.pending.len() >= self.config.max_queue_depth {
+            return Err(QueueError::QueueFull {
+                depth: inner.pending.len(),
+                max: self.config.max_queue_depth,
+            });
+        }
+        let mut msg = message;
+        msg.queued_at = Some(Instant::now());
+        inner.pending.push_back(msg);
+        Ok(())
+    }
+
+    /// Remove a specific queued message by ID.
+    pub fn remove(&self, id: &str) -> Result<QueuedMessage, QueueError> {
+        let mut inner = self.inner.lock().expect("queue lock poisoned");
+        let pos = inner
+            .pending
+            .iter()
+            .position(|m| m.id == id)
+            .ok_or_else(|| QueueError::NotFound { id: id.to_owned() })?;
+        Ok(inner.pending.remove(pos).expect("position valid"))
+    }
+
+    /// Get a snapshot of the current queue state.
+    pub fn status(&self) -> QueueStatus {
+        let inner = self.inner.lock().expect("queue lock poisoned");
+        let oldest_age = inner
+            .pending
+            .front()
+            .and_then(|m| m.queued_at.map(|t| t.elapsed().as_millis() as u64));
+        QueueStatus {
+            depth: inner.pending.len(),
+            pending: inner.pending.iter().cloned().collect(),
+            has_active_run: inner.has_active_run,
+            oldest_message_age_ms: oldest_age,
+        }
+    }
+
+    /// Mark that an active run has started.
+    pub fn set_active_run(&self, active: bool) {
+        let mut inner = self.inner.lock().expect("queue lock poisoned");
+        inner.has_active_run = active;
+    }
+
+    /// Whether there is an active run.
+    pub fn has_active_run(&self) -> bool {
+        let inner = self.inner.lock().expect("queue lock poisoned");
+        inner.has_active_run
+    }
+
+    /// Check for preemption at a tool boundary.
+    ///
+    /// Inspects the queue for `Interrupt` or `Steer` messages and returns
+    /// the appropriate `SteeringAction`. Priority: interrupt > steer.
+    pub fn check_preemption(&self) -> SteeringAction {
+        let mut inner = self.inner.lock().expect("queue lock poisoned");
+
+        // Priority 1: Interrupt messages — abort immediately
+        if let Some(pos) = inner
+            .pending
+            .iter()
+            .position(|m| m.mode == SteeringMode::Interrupt)
+        {
+            let msg = inner.pending.remove(pos).expect("position valid");
+            return SteeringAction::Abort {
+                reason: format!("interrupted by queue message: {}", msg.id),
+            };
+        }
+
+        // Priority 2: Steer messages — complete and switch
+        if let Some(pos) = inner
+            .pending
+            .iter()
+            .position(|m| m.mode == SteeringMode::Steer)
+        {
+            let msg = inner.pending.remove(pos).expect("position valid");
+            return SteeringAction::CompleteAndSwitch(msg);
+        }
+
+        SteeringAction::Continue
+    }
+
+    /// Drain messages after a run completes, in priority order.
+    ///
+    /// Returns messages ordered: followup first (same context), then collect (fresh runs).
+    /// Collect messages within the coalesce window are batched together.
+    pub fn drain_after_run(&self) -> Vec<QueuedMessage> {
+        let mut inner = self.inner.lock().expect("queue lock poisoned");
+        inner.has_active_run = false;
+
+        if inner.pending.is_empty() {
+            return Vec::new();
+        }
+
+        let mut followups = Vec::new();
+        let mut collects = Vec::new();
+        let mut remaining = VecDeque::new();
+
+        for msg in inner.pending.drain(..) {
+            match msg.mode {
+                SteeringMode::Followup => followups.push(msg),
+                SteeringMode::Collect => collects.push(msg),
+                // Interrupt/Steer messages that weren't consumed during the run
+                // are treated as fresh collects.
+                SteeringMode::Interrupt | SteeringMode::Steer => collects.push(msg),
+            }
+        }
+
+        // Coalesce collect messages within the window
+        let window = self.config.collect_coalesce_window;
+        if collects.len() > 1 {
+            let now = Instant::now();
+            let (within_window, outside): (Vec<_>, Vec<_>) = collects
+                .into_iter()
+                .partition(|m| m.queued_at.is_some_and(|t| now.duration_since(t) <= window));
+            // Keep outside-window messages as individual items
+            for msg in outside {
+                remaining.push_back(msg);
+            }
+            collects = within_window;
+        }
+
+        inner.pending = remaining;
+
+        // Return in priority order: followups first, then collects
+        let mut result = followups;
+        result.extend(collects);
+        result
+    }
+
+    /// Check queue health for heartbeat integration (Phase 2.4).
+    ///
+    /// Returns warnings if queue depth exceeds threshold or messages are stale.
+    pub fn health_check(&self) -> Vec<String> {
+        let inner = self.inner.lock().expect("queue lock poisoned");
+        let mut warnings = Vec::new();
+
+        let depth = inner.pending.len();
+        let threshold = self.config.max_queue_depth / 2;
+        if depth > threshold {
+            warnings.push(format!(
+                "queue depth {depth} exceeds warning threshold {threshold}"
+            ));
+        }
+
+        let stale_timeout = self.config.steer_timeout * 2;
+        if let Some(oldest) = inner.pending.front() {
+            if let Some(queued_at) = oldest.queued_at {
+                if queued_at.elapsed() > stale_timeout {
+                    warnings.push(format!(
+                        "oldest message {} is stale ({:.1}s old)",
+                        oldest.id,
+                        queued_at.elapsed().as_secs_f64()
+                    ));
+                }
+            }
+        }
+
+        warnings
+    }
+
+    /// Current queue depth.
+    pub fn depth(&self) -> usize {
+        let inner = self.inner.lock().expect("queue lock poisoned");
+        inner.pending.len()
+    }
+
+    /// Get a reference to the queue config.
+    pub fn config(&self) -> &QueueConfig {
+        &self.config
+    }
+}
+
+impl PreemptionCheck for MessageQueue {
+    fn check_preemption(&self) -> SteeringAction {
+        self.check_preemption()
+    }
+}
+
+impl Clone for MessageQueue {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            config: self.config.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_msg(id: &str, mode: SteeringMode, content: &str) -> QueuedMessage {
+        QueuedMessage {
+            id: id.to_string(),
+            mode,
+            content: content.to_string(),
+            queued_at: None,
+        }
+    }
+
+    #[test]
+    fn collect_mode_queued_and_drained() {
+        let queue = MessageQueue::new(QueueConfig::default());
+        queue.set_active_run(true);
+
+        queue
+            .enqueue(make_msg("q1", SteeringMode::Collect, "do this later"))
+            .unwrap();
+
+        assert_eq!(queue.depth(), 1);
+        assert!(queue.has_active_run());
+
+        // Preemption check should return Continue (collect doesn't preempt)
+        assert!(matches!(queue.check_preemption(), SteeringAction::Continue));
+
+        let drained = queue.drain_after_run();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].id, "q1");
+        assert!(!queue.has_active_run());
+    }
+
+    #[test]
+    fn steer_mode_preempts_at_tool_boundary() {
+        let queue = MessageQueue::new(QueueConfig::default());
+        queue.set_active_run(true);
+
+        queue
+            .enqueue(make_msg("q1", SteeringMode::Steer, "do this instead"))
+            .unwrap();
+
+        match queue.check_preemption() {
+            SteeringAction::CompleteAndSwitch(msg) => {
+                assert_eq!(msg.id, "q1");
+                assert_eq!(msg.content, "do this instead");
+            }
+            other => panic!("expected CompleteAndSwitch, got {other:?}"),
+        }
+
+        // Queue should be empty after steer consumed
+        assert_eq!(queue.depth(), 0);
+    }
+
+    #[test]
+    fn followup_inherits_context_order() {
+        let queue = MessageQueue::new(QueueConfig::default());
+        queue.set_active_run(true);
+
+        queue
+            .enqueue(make_msg("c1", SteeringMode::Collect, "fresh run"))
+            .unwrap();
+        queue
+            .enqueue(make_msg("f1", SteeringMode::Followup, "same context"))
+            .unwrap();
+
+        let drained = queue.drain_after_run();
+        // Followup comes before Collect
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].id, "f1");
+        assert_eq!(drained[1].id, "c1");
+    }
+
+    #[test]
+    fn interrupt_aborts_at_tool_boundary() {
+        let queue = MessageQueue::new(QueueConfig::default());
+        queue.set_active_run(true);
+
+        queue
+            .enqueue(make_msg("i1", SteeringMode::Interrupt, "stop now"))
+            .unwrap();
+
+        match queue.check_preemption() {
+            SteeringAction::Abort { reason } => {
+                assert!(reason.contains("i1"));
+            }
+            other => panic!("expected Abort, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn queue_depth_limit_enforced() {
+        let config = QueueConfig {
+            max_queue_depth: 2,
+            ..Default::default()
+        };
+        let queue = MessageQueue::new(config);
+
+        queue
+            .enqueue(make_msg("q1", SteeringMode::Collect, "1"))
+            .unwrap();
+        queue
+            .enqueue(make_msg("q2", SteeringMode::Collect, "2"))
+            .unwrap();
+
+        let result = queue.enqueue(make_msg("q3", SteeringMode::Collect, "3"));
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            QueueError::QueueFull { depth: 2, max: 2 }
+        ));
+    }
+
+    #[test]
+    fn steer_timeout_falls_back_to_collect() {
+        // If no tool boundary occurs within timeout, steer messages
+        // are treated as collect messages when drained.
+        let queue = MessageQueue::new(QueueConfig::default());
+        queue.set_active_run(true);
+
+        queue
+            .enqueue(make_msg("s1", SteeringMode::Steer, "should steer"))
+            .unwrap();
+
+        // Simulate: we never call check_preemption, run finishes naturally
+        let drained = queue.drain_after_run();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].id, "s1");
+    }
+
+    #[test]
+    fn collect_messages_coalesced_within_window() {
+        let config = QueueConfig {
+            collect_coalesce_window: Duration::from_secs(10), // large window
+            ..Default::default()
+        };
+        let queue = MessageQueue::new(config);
+        queue.set_active_run(true);
+
+        // All messages queued close together
+        queue
+            .enqueue(make_msg("c1", SteeringMode::Collect, "a"))
+            .unwrap();
+        queue
+            .enqueue(make_msg("c2", SteeringMode::Collect, "b"))
+            .unwrap();
+        queue
+            .enqueue(make_msg("c3", SteeringMode::Collect, "c"))
+            .unwrap();
+
+        let drained = queue.drain_after_run();
+        // All should be drained together
+        assert_eq!(drained.len(), 3);
+    }
+
+    #[test]
+    fn drain_order_interrupt_steer_followup_collect() {
+        let queue = MessageQueue::new(QueueConfig::default());
+        queue.set_active_run(true);
+
+        queue
+            .enqueue(make_msg("c1", SteeringMode::Collect, "collect"))
+            .unwrap();
+        queue
+            .enqueue(make_msg("f1", SteeringMode::Followup, "followup"))
+            .unwrap();
+        queue
+            .enqueue(make_msg("i1", SteeringMode::Interrupt, "interrupt"))
+            .unwrap();
+        queue
+            .enqueue(make_msg("s1", SteeringMode::Steer, "steer"))
+            .unwrap();
+
+        // Preemption should pick up interrupt first (highest priority)
+        match queue.check_preemption() {
+            SteeringAction::Abort { .. } => {}
+            other => panic!("expected Abort from interrupt, got {other:?}"),
+        }
+
+        // Next preemption check should pick steer
+        match queue.check_preemption() {
+            SteeringAction::CompleteAndSwitch(msg) => assert_eq!(msg.id, "s1"),
+            other => panic!("expected CompleteAndSwitch from steer, got {other:?}"),
+        }
+
+        // Drain remaining: followup before collect
+        let drained = queue.drain_after_run();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].id, "f1");
+        assert_eq!(drained[1].id, "c1");
+    }
+
+    #[test]
+    fn preemption_returns_continue_on_empty_queue() {
+        let queue = MessageQueue::new(QueueConfig::default());
+        assert!(matches!(queue.check_preemption(), SteeringAction::Continue));
+    }
+
+    #[test]
+    fn remove_specific_message() {
+        let queue = MessageQueue::new(QueueConfig::default());
+        queue
+            .enqueue(make_msg("q1", SteeringMode::Collect, "a"))
+            .unwrap();
+        queue
+            .enqueue(make_msg("q2", SteeringMode::Collect, "b"))
+            .unwrap();
+
+        let removed = queue.remove("q1").unwrap();
+        assert_eq!(removed.id, "q1");
+        assert_eq!(queue.depth(), 1);
+
+        // Removing non-existent returns error
+        assert!(queue.remove("q99").is_err());
+    }
+
+    #[test]
+    fn status_snapshot() {
+        let queue = MessageQueue::new(QueueConfig::default());
+        queue.set_active_run(true);
+        queue
+            .enqueue(make_msg("q1", SteeringMode::Collect, "test"))
+            .unwrap();
+
+        let status = queue.status();
+        assert_eq!(status.depth, 1);
+        assert!(status.has_active_run);
+        assert_eq!(status.pending.len(), 1);
+        assert!(status.oldest_message_age_ms.is_some());
+    }
+
+    #[test]
+    fn health_check_warns_on_depth() {
+        let config = QueueConfig {
+            max_queue_depth: 4,
+            ..Default::default()
+        };
+        let queue = MessageQueue::new(config);
+
+        // Fill past half
+        for i in 0..3 {
+            queue
+                .enqueue(make_msg(&format!("q{i}"), SteeringMode::Collect, "x"))
+                .unwrap();
+        }
+
+        let warnings = queue.health_check();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("exceeds warning threshold"))
+        );
+    }
+
+    #[test]
+    fn clone_shares_state() {
+        let queue = MessageQueue::new(QueueConfig::default());
+        let queue2 = queue.clone();
+
+        queue
+            .enqueue(make_msg("q1", SteeringMode::Collect, "shared"))
+            .unwrap();
+        assert_eq!(queue2.depth(), 1);
+    }
+
+    #[test]
+    fn multiple_followups_preserved_in_order() {
+        let queue = MessageQueue::new(QueueConfig::default());
+        queue.set_active_run(true);
+
+        queue
+            .enqueue(make_msg("f1", SteeringMode::Followup, "first"))
+            .unwrap();
+        queue
+            .enqueue(make_msg("f2", SteeringMode::Followup, "second"))
+            .unwrap();
+        queue
+            .enqueue(make_msg("f3", SteeringMode::Followup, "third"))
+            .unwrap();
+
+        let drained = queue.drain_after_run();
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0].id, "f1");
+        assert_eq!(drained[1].id, "f2");
+        assert_eq!(drained[2].id, "f3");
+    }
+
+    #[test]
+    fn drain_empty_queue_returns_empty() {
+        let queue = MessageQueue::new(QueueConfig::default());
+        queue.set_active_run(true);
+        let drained = queue.drain_after_run();
+        assert!(drained.is_empty());
+    }
+}

--- a/crates/arcan-fleet/Cargo.toml
+++ b/crates/arcan-fleet/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "arcan-fleet"
+description = "Vertical agent fleet — coding, data processing, and support agents for the Life marketplace"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+arcan-core = { path = "../arcan-core" }
+haima-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/arcan-fleet/src/coding.rs
+++ b/crates/arcan-fleet/src/coding.rs
@@ -1,0 +1,93 @@
+//! Coding agent vertical — code review, bug fixes, refactoring, test writing.
+//!
+//! This agent has full Praxis tool access including `edit_file` and `bash`.
+//! It earns revenue per PR reviewed, per bug fixed, and per test suite written.
+
+use crate::vertical::{AgentVertical, ToolPermissions, VerticalConfig};
+
+/// Coding agent persona — injected as the Persona context block.
+const PERSONA: &str = "\
+You are a senior software engineer agent specializing in code review, bug fixing, \
+refactoring, and test writing. You operate within the Life Agent OS ecosystem.\n\
+\n\
+## Core capabilities\n\
+- **Code review**: Analyze pull requests for correctness, style, security, and performance\n\
+- **Bug fixing**: Diagnose root causes from error reports and implement targeted fixes\n\
+- **Refactoring**: Restructure code for clarity, maintainability, and performance\n\
+- **Test writing**: Generate comprehensive unit, integration, and property-based tests\n\
+\n\
+## Working style\n\
+- Read the full context before making changes — understand the codebase first\n\
+- Make minimal, focused changes — solve the stated problem, nothing more\n\
+- Use hashline-based editing (Blake3 tags) to prevent stale edits\n\
+- Always verify changes compile and pass existing tests before reporting completion\n\
+- Explain your reasoning concisely in tool results\n\
+\n\
+## Languages & ecosystems\n\
+- Rust (primary): idiomatic patterns, ownership, lifetimes, async\n\
+- TypeScript/JavaScript: Node.js, React, Next.js\n\
+- Python: data pipelines, FastAPI, Django\n\
+- Go, Java, C++ (secondary)\n\
+\n\
+## Quality standards\n\
+- No new warnings (clippy -D warnings for Rust, strict TypeScript)\n\
+- Tests for every behavioral change\n\
+- Security-first: no injection vectors, no leaked secrets\n\
+- Clear commit messages referencing the task";
+
+/// Coding agent behavioral rules.
+const RULES: &str = "\
+## Operational rules\n\
+1. Never modify files outside the designated workspace boundary\n\
+2. Always run `cargo check` or equivalent before reporting a task as complete\n\
+3. If tests fail after your changes, fix them before completing the task\n\
+4. Never commit secrets, API keys, or credentials\n\
+5. If a task is ambiguous, ask for clarification via the task message channel\n\
+6. Prefer small, atomic changes over large refactors unless explicitly requested\n\
+7. Document non-obvious decisions with inline comments\n\
+8. Respect existing code style and conventions — match the surrounding code\n\
+\n\
+## Economic rules\n\
+- Bill only after successful verification (tests pass, review approved)\n\
+- Report complexity honestly: Simple for trivial fixes, Critical for security patches\n\
+- If blocked for >15 minutes, escalate rather than burning compute budget";
+
+/// Build the coding agent configuration.
+pub fn config() -> VerticalConfig {
+    VerticalConfig::new(
+        AgentVertical::Coding,
+        "life-coding-agent-v1",
+        "Life Coding Agent",
+        "Expert code review, bug fixing, refactoring, and test writing agent. \
+         Supports Rust, TypeScript, Python, and more. Outcome-priced per PR or bug fix.",
+        PERSONA,
+        RULES,
+        ToolPermissions::full(),
+        24, // max iterations — coding tasks can be multi-step
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coding_config_valid() {
+        let cfg = config();
+        assert_eq!(cfg.agent_id(), "life-coding-agent-v1");
+        assert_eq!(cfg.vertical, AgentVertical::Coding);
+        assert_eq!(cfg.max_iterations, 24);
+        assert!(cfg.persona().contains("code review"));
+        assert!(cfg.rules().contains("cargo check"));
+    }
+
+    #[test]
+    fn coding_has_full_tools() {
+        let cfg = config();
+        let tools = cfg.tools.enabled_tools();
+        assert!(tools.contains(&"edit_file"));
+        assert!(tools.contains(&"bash"));
+        assert!(tools.contains(&"write_file"));
+        assert_eq!(tools.len(), 9);
+    }
+}

--- a/crates/arcan-fleet/src/contracts.rs
+++ b/crates/arcan-fleet/src/contracts.rs
@@ -1,0 +1,264 @@
+//! Haima task contracts for each agent vertical.
+//!
+//! Each contract defines outcome-based pricing, success criteria, and SLA.
+//! These are registered with the Haima outcome engine at agent startup.
+
+use crate::vertical::AgentVertical;
+use haima_core::outcome::{RefundPolicy, SuccessCriterion, TaskComplexity, TaskContract, TaskType};
+
+/// Return the primary Haima task contract for a vertical.
+pub fn contract_for(vertical: AgentVertical) -> TaskContract {
+    match vertical {
+        AgentVertical::Coding => coding_contract(),
+        AgentVertical::DataProcessing => data_contract(),
+        AgentVertical::Support => support_contract(),
+    }
+}
+
+/// Return all contracts for a vertical (primary + sub-task variants).
+pub fn all_contracts_for(vertical: AgentVertical) -> Vec<TaskContract> {
+    match vertical {
+        AgentVertical::Coding => vec![
+            coding_contract(),
+            coding_bug_fix_contract(),
+            coding_test_writing_contract(),
+        ],
+        AgentVertical::DataProcessing => vec![data_contract(), data_report_contract()],
+        AgentVertical::Support => vec![support_contract()],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Coding contracts
+// ---------------------------------------------------------------------------
+
+/// Code review contract: $2 - $5 per PR.
+fn coding_contract() -> TaskContract {
+    TaskContract {
+        contract_id: "fleet-coding-review-v1".into(),
+        task_type: TaskType::CodeReview,
+        name: "Code Review (Fleet)".into(),
+        price_floor_micro_credits: 2_000_000,   // $2.00
+        price_ceiling_micro_credits: 5_000_000, // $5.00
+        success_criteria: vec![
+            SuccessCriterion::TestsPassed {
+                scope: "unit".into(),
+            },
+            SuccessCriterion::Custom {
+                description: "Code compiles without new warnings".into(),
+            },
+        ],
+        refund_policy: RefundPolicy {
+            sla_seconds: 7200, // 2 hours
+            ..RefundPolicy::default()
+        },
+        min_trust_score: 0.3,
+        custom_label: None,
+        created_at: chrono::Utc::now(),
+    }
+}
+
+/// Bug fix contract: $3 - $8 per fix (higher than review due to investigation).
+fn coding_bug_fix_contract() -> TaskContract {
+    TaskContract {
+        contract_id: "fleet-coding-bugfix-v1".into(),
+        task_type: TaskType::CodeReview, // reuse CodeReview type
+        name: "Bug Fix (Fleet)".into(),
+        price_floor_micro_credits: 3_000_000,   // $3.00
+        price_ceiling_micro_credits: 8_000_000, // $8.00
+        success_criteria: vec![
+            SuccessCriterion::TestsPassed {
+                scope: "unit".into(),
+            },
+            SuccessCriterion::TestsPassed {
+                scope: "integration".into(),
+            },
+            SuccessCriterion::Custom {
+                description: "Bug reproduction test passes".into(),
+            },
+        ],
+        refund_policy: RefundPolicy {
+            sla_seconds: 3600, // 1 hour
+            ..RefundPolicy::default()
+        },
+        min_trust_score: 0.5,
+        custom_label: Some("bug_fix".into()),
+        created_at: chrono::Utc::now(),
+    }
+}
+
+/// Test writing contract: $1 - $4 per test suite.
+fn coding_test_writing_contract() -> TaskContract {
+    TaskContract {
+        contract_id: "fleet-coding-tests-v1".into(),
+        task_type: TaskType::CodeReview,
+        name: "Test Writing (Fleet)".into(),
+        price_floor_micro_credits: 1_000_000,   // $1.00
+        price_ceiling_micro_credits: 4_000_000, // $4.00
+        success_criteria: vec![
+            SuccessCriterion::TestsPassed {
+                scope: "unit".into(),
+            },
+            SuccessCriterion::Custom {
+                description: "New tests cover the specified functions".into(),
+            },
+        ],
+        refund_policy: RefundPolicy {
+            sla_seconds: 3600,
+            ..RefundPolicy::default()
+        },
+        min_trust_score: 0.3,
+        custom_label: Some("test_writing".into()),
+        created_at: chrono::Utc::now(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Data processing contracts
+// ---------------------------------------------------------------------------
+
+/// Data pipeline contract: $5 - $20 per pipeline run.
+fn data_contract() -> TaskContract {
+    TaskContract {
+        contract_id: "fleet-data-pipeline-v1".into(),
+        task_type: TaskType::DataPipeline,
+        name: "Data Pipeline (Fleet)".into(),
+        price_floor_micro_credits: 5_000_000,    // $5.00
+        price_ceiling_micro_credits: 20_000_000, // $20.00
+        success_criteria: vec![
+            SuccessCriterion::DataValidated {
+                rule_id: "pipeline-output-schema".into(),
+            },
+            SuccessCriterion::Custom {
+                description: "Output row count matches expected range".into(),
+            },
+        ],
+        refund_policy: RefundPolicy {
+            sla_seconds: 3600, // 1 hour
+            ..RefundPolicy::default()
+        },
+        min_trust_score: 0.5,
+        custom_label: None,
+        created_at: chrono::Utc::now(),
+    }
+}
+
+/// Report generation contract: $2 - $10 per report.
+fn data_report_contract() -> TaskContract {
+    TaskContract {
+        contract_id: "fleet-data-report-v1".into(),
+        task_type: TaskType::DocumentGeneration,
+        name: "Report Generation (Fleet)".into(),
+        price_floor_micro_credits: 2_000_000,    // $2.00
+        price_ceiling_micro_credits: 10_000_000, // $10.00
+        success_criteria: vec![SuccessCriterion::DataValidated {
+            rule_id: "document-schema".into(),
+        }],
+        refund_policy: RefundPolicy {
+            sla_seconds: 1800, // 30 minutes
+            ..RefundPolicy::default()
+        },
+        min_trust_score: 0.3,
+        custom_label: None,
+        created_at: chrono::Utc::now(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Support contracts
+// ---------------------------------------------------------------------------
+
+/// Support ticket contract: $0.50 - $2.00 per ticket.
+fn support_contract() -> TaskContract {
+    TaskContract {
+        contract_id: "fleet-support-ticket-v1".into(),
+        task_type: TaskType::SupportTicket,
+        name: "Support Ticket (Fleet)".into(),
+        price_floor_micro_credits: 500_000,     // $0.50
+        price_ceiling_micro_credits: 2_000_000, // $2.00
+        success_criteria: vec![SuccessCriterion::Custom {
+            description: "Customer confirmed resolution or ticket closed".into(),
+        }],
+        refund_policy: RefundPolicy {
+            sla_seconds: 1800, // 30 minutes
+            ..RefundPolicy::default()
+        },
+        min_trust_score: 0.3,
+        custom_label: None,
+        created_at: chrono::Utc::now(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pricing utilities
+// ---------------------------------------------------------------------------
+
+/// Estimate the price for a task given vertical, complexity, and trust score.
+pub fn estimate_price(
+    vertical: AgentVertical,
+    complexity: TaskComplexity,
+    trust_score: f64,
+) -> i64 {
+    contract_for(vertical).resolve_price(complexity, trust_score)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_contracts_have_valid_ranges() {
+        for vertical in [
+            AgentVertical::Coding,
+            AgentVertical::DataProcessing,
+            AgentVertical::Support,
+        ] {
+            for contract in all_contracts_for(vertical) {
+                assert!(
+                    contract.price_floor_micro_credits > 0,
+                    "{} has zero floor",
+                    contract.contract_id
+                );
+                assert!(
+                    contract.price_floor_micro_credits <= contract.price_ceiling_micro_credits,
+                    "{} has floor > ceiling",
+                    contract.contract_id
+                );
+                assert!(
+                    !contract.success_criteria.is_empty(),
+                    "{} has no criteria",
+                    contract.contract_id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn coding_has_three_contracts() {
+        assert_eq!(all_contracts_for(AgentVertical::Coding).len(), 3);
+    }
+
+    #[test]
+    fn data_has_two_contracts() {
+        assert_eq!(all_contracts_for(AgentVertical::DataProcessing).len(), 2);
+    }
+
+    #[test]
+    fn support_has_one_contract() {
+        assert_eq!(all_contracts_for(AgentVertical::Support).len(), 1);
+    }
+
+    #[test]
+    fn estimate_price_within_range() {
+        let price = estimate_price(AgentVertical::Coding, TaskComplexity::Standard, 0.5);
+        assert!(price >= 2_000_000);
+        assert!(price <= 5_000_000);
+    }
+
+    #[test]
+    fn support_cheapest_vertical() {
+        let support = estimate_price(AgentVertical::Support, TaskComplexity::Simple, 0.0);
+        let coding = estimate_price(AgentVertical::Coding, TaskComplexity::Simple, 0.0);
+        assert!(support < coding);
+    }
+}

--- a/crates/arcan-fleet/src/data.rs
+++ b/crates/arcan-fleet/src/data.rs
@@ -1,0 +1,92 @@
+//! Data processing agent vertical — ETL pipelines, data cleaning, report generation.
+//!
+//! This agent has read/write filesystem access and `bash` for pipeline execution,
+//! but no `edit_file` (it creates new files rather than editing existing code).
+//! It earns revenue per pipeline run and per report generated.
+
+use crate::vertical::{AgentVertical, ToolPermissions, VerticalConfig};
+
+/// Data processing agent persona.
+const PERSONA: &str = "\
+You are a data engineering agent specializing in ETL pipelines, data cleaning, \
+transformation, and report generation. You operate within the Life Agent OS ecosystem.\n\
+\n\
+## Core capabilities\n\
+- **ETL pipelines**: Extract data from APIs, databases, and files; transform and load\n\
+- **Data cleaning**: Detect and fix anomalies, missing values, format inconsistencies\n\
+- **Report generation**: Produce structured reports (JSON, CSV, Markdown) from raw data\n\
+- **Schema validation**: Verify data conforms to expected schemas\n\
+- **Aggregation**: Compute summaries, statistics, and derived metrics\n\
+\n\
+## Working style\n\
+- Validate inputs before processing — fail fast on malformed data\n\
+- Write output files atomically (temp file → rename) to prevent partial writes\n\
+- Log progress for long-running pipelines so status is observable\n\
+- Use streaming where possible to handle large datasets without memory exhaustion\n\
+- Include row counts and checksums in output metadata for verification\n\
+\n\
+## Tools & formats\n\
+- Shell pipelines: jq, awk, sed, sort, uniq for text processing\n\
+- Python scripts for complex transformations (pandas, polars)\n\
+- SQL queries via CLI clients (psql, sqlite3)\n\
+- JSON, CSV, Parquet, NDJSON\n\
+\n\
+## Quality standards\n\
+- Every output includes a manifest (row count, schema hash, timestamp)\n\
+- Data validation runs before and after transformation\n\
+- Idempotent operations — re-running produces the same result\n\
+- No data loss: preserve originals, write to new files";
+
+/// Data processing agent behavioral rules.
+const RULES: &str = "\
+## Operational rules\n\
+1. Never modify source data files — always write to new output paths\n\
+2. Validate output schema before reporting task as complete\n\
+3. Include error counts and data quality metrics in every pipeline result\n\
+4. Cap memory usage: stream large files instead of loading entirely\n\
+5. Time-bound operations: abort and report if a step exceeds 10 minutes\n\
+6. Write checkpoint files for multi-step pipelines so they can resume\n\
+\n\
+## Economic rules\n\
+- Bill after output validation passes (DataValidated criterion)\n\
+- Complexity = Simple for <1K rows, Standard for 1K-1M, Complex for >1M\n\
+- Report accurate row counts in task completion messages";
+
+/// Build the data processing agent configuration.
+pub fn config() -> VerticalConfig {
+    VerticalConfig::new(
+        AgentVertical::DataProcessing,
+        "life-data-agent-v1",
+        "Life Data Processing Agent",
+        "ETL pipelines, data cleaning, and report generation agent. \
+         Handles CSV, JSON, SQL, and streaming data. Outcome-priced per pipeline run.",
+        PERSONA,
+        RULES,
+        ToolPermissions::data_processing(),
+        16, // max iterations — pipelines are usually linear
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_config_valid() {
+        let cfg = config();
+        assert_eq!(cfg.agent_id(), "life-data-agent-v1");
+        assert_eq!(cfg.vertical, AgentVertical::DataProcessing);
+        assert_eq!(cfg.max_iterations, 16);
+        assert!(cfg.persona().contains("ETL"));
+        assert!(cfg.rules().contains("output validation"));
+    }
+
+    #[test]
+    fn data_has_bash_but_no_edit() {
+        let cfg = config();
+        let tools = cfg.tools.enabled_tools();
+        assert!(tools.contains(&"bash"));
+        assert!(tools.contains(&"write_file"));
+        assert!(!tools.contains(&"edit_file"));
+    }
+}

--- a/crates/arcan-fleet/src/health.rs
+++ b/crates/arcan-fleet/src/health.rs
@@ -1,0 +1,196 @@
+//! Health reporting configuration for fleet agents.
+//!
+//! Defines thresholds and health snapshot data structures that map to
+//! the Spaces `AgentHealthSnapshot` table and Autonomic's three-pillar model.
+
+use crate::vertical::AgentVertical;
+use serde::{Deserialize, Serialize};
+
+/// Health thresholds for a fleet agent.
+///
+/// These map to the Autonomic controller's gating profile and
+/// determine when an agent is considered healthy vs degraded.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthThresholds {
+    /// Maximum consecutive errors before degraded status.
+    pub max_error_streak: u32,
+    /// Maximum context pressure (0.0-1.0) before pausing.
+    pub max_context_pressure: f64,
+    /// Minimum budget remaining percentage before entering conserving mode.
+    pub min_budget_remaining_pct: f64,
+    /// Maximum uncertainty (0.0-1.0) before requesting human review.
+    pub max_uncertainty: f64,
+    /// Target tasks per hour for throughput monitoring.
+    pub target_tasks_per_hour: u32,
+}
+
+/// Health snapshot for reporting to Spaces.
+///
+/// Maps directly to the `update_health_snapshot` reducer parameters.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FleetHealthSnapshot {
+    /// Agent vertical.
+    pub vertical: AgentVertical,
+    /// Current task progress (0.0-1.0).
+    pub progress: f64,
+    /// Current uncertainty level (0.0-1.0).
+    pub uncertainty: f64,
+    /// Consecutive error count.
+    pub error_streak: u32,
+    /// Context window pressure (0.0-1.0).
+    pub context_pressure: f64,
+    /// Budget remaining percentage (0.0-100.0).
+    pub budget_remaining_pct: f64,
+    /// Current economic operating mode.
+    pub operating_mode: String,
+    /// Whether the agent is currently online and accepting tasks.
+    pub is_online: bool,
+    /// Tasks completed in the current reporting period.
+    pub tasks_completed: u32,
+    /// Tasks failed in the current reporting period.
+    pub tasks_failed: u32,
+}
+
+impl FleetHealthSnapshot {
+    /// Check if the agent is healthy given its thresholds.
+    pub fn is_healthy(&self, thresholds: &HealthThresholds) -> bool {
+        self.is_online
+            && self.error_streak <= thresholds.max_error_streak
+            && self.context_pressure <= thresholds.max_context_pressure
+            && self.budget_remaining_pct >= thresholds.min_budget_remaining_pct
+            && self.uncertainty <= thresholds.max_uncertainty
+    }
+
+    /// Compute a health score (0-100) for the Spaces listing.
+    pub fn health_score(&self, thresholds: &HealthThresholds) -> u32 {
+        if !self.is_online {
+            return 0;
+        }
+
+        let mut score: f64 = 100.0;
+
+        // Error streak penalty: -10 per error, capped
+        let error_penalty = (self.error_streak as f64 / thresholds.max_error_streak as f64) * 30.0;
+        score -= error_penalty.min(30.0);
+
+        // Context pressure penalty
+        let pressure_penalty = (self.context_pressure / thresholds.max_context_pressure) * 20.0;
+        score -= pressure_penalty.min(20.0);
+
+        // Budget penalty
+        let budget_ratio = self.budget_remaining_pct / 100.0;
+        if budget_ratio < thresholds.min_budget_remaining_pct / 100.0 {
+            score -= 25.0;
+        }
+
+        // Uncertainty penalty
+        let uncertainty_penalty = (self.uncertainty / thresholds.max_uncertainty) * 25.0;
+        score -= uncertainty_penalty.min(25.0);
+
+        score.clamp(0.0, 100.0) as u32
+    }
+}
+
+/// Default health thresholds per vertical.
+pub fn thresholds_for(vertical: AgentVertical) -> HealthThresholds {
+    match vertical {
+        AgentVertical::Coding => HealthThresholds {
+            max_error_streak: 3,
+            max_context_pressure: 0.85,
+            min_budget_remaining_pct: 15.0,
+            max_uncertainty: 0.7,
+            target_tasks_per_hour: 10,
+        },
+        AgentVertical::DataProcessing => HealthThresholds {
+            max_error_streak: 2,
+            max_context_pressure: 0.80,
+            min_budget_remaining_pct: 20.0,
+            max_uncertainty: 0.6,
+            target_tasks_per_hour: 8,
+        },
+        AgentVertical::Support => HealthThresholds {
+            max_error_streak: 5, // more tolerant — some tickets are ambiguous
+            max_context_pressure: 0.90,
+            min_budget_remaining_pct: 10.0,
+            max_uncertainty: 0.8,      // higher tolerance for uncertainty
+            target_tasks_per_hour: 20, // support is high-throughput, low-complexity
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn healthy_snapshot(vertical: AgentVertical) -> FleetHealthSnapshot {
+        FleetHealthSnapshot {
+            vertical,
+            progress: 0.5,
+            uncertainty: 0.2,
+            error_streak: 0,
+            context_pressure: 0.3,
+            budget_remaining_pct: 80.0,
+            operating_mode: "sovereign".into(),
+            is_online: true,
+            tasks_completed: 10,
+            tasks_failed: 0,
+        }
+    }
+
+    #[test]
+    fn healthy_agent_passes() {
+        let snap = healthy_snapshot(AgentVertical::Coding);
+        let thresh = thresholds_for(AgentVertical::Coding);
+        assert!(snap.is_healthy(&thresh));
+    }
+
+    #[test]
+    fn offline_agent_not_healthy() {
+        let mut snap = healthy_snapshot(AgentVertical::Coding);
+        snap.is_online = false;
+        let thresh = thresholds_for(AgentVertical::Coding);
+        assert!(!snap.is_healthy(&thresh));
+    }
+
+    #[test]
+    fn error_streak_degrades_health() {
+        let mut snap = healthy_snapshot(AgentVertical::Coding);
+        snap.error_streak = 5;
+        let thresh = thresholds_for(AgentVertical::Coding);
+        assert!(!snap.is_healthy(&thresh));
+    }
+
+    #[test]
+    fn healthy_agent_scores_high() {
+        let snap = healthy_snapshot(AgentVertical::Coding);
+        let thresh = thresholds_for(AgentVertical::Coding);
+        let score = snap.health_score(&thresh);
+        assert!(score >= 70, "expected >= 70, got {score}");
+    }
+
+    #[test]
+    fn offline_agent_scores_zero() {
+        let mut snap = healthy_snapshot(AgentVertical::Coding);
+        snap.is_online = false;
+        let thresh = thresholds_for(AgentVertical::Coding);
+        assert_eq!(snap.health_score(&thresh), 0);
+    }
+
+    #[test]
+    fn degraded_agent_scores_lower() {
+        let mut snap = healthy_snapshot(AgentVertical::DataProcessing);
+        snap.error_streak = 2;
+        snap.uncertainty = 0.5;
+        snap.context_pressure = 0.7;
+        let thresh = thresholds_for(AgentVertical::DataProcessing);
+        let score = snap.health_score(&thresh);
+        assert!(score < 70, "expected < 70, got {score}");
+    }
+
+    #[test]
+    fn support_higher_throughput_target() {
+        let coding = thresholds_for(AgentVertical::Coding);
+        let support = thresholds_for(AgentVertical::Support);
+        assert!(support.target_tasks_per_hour > coding.target_tasks_per_hour);
+    }
+}

--- a/crates/arcan-fleet/src/lib.rs
+++ b/crates/arcan-fleet/src/lib.rs
@@ -1,0 +1,111 @@
+//! Vertical agent fleet for the Life marketplace.
+//!
+//! Defines three production agent verticals — Coding, Data Processing, and Support —
+//! each with a complete profile: system prompt, tool permissions, Haima task contracts,
+//! and Spaces marketplace listing data.
+//!
+//! # Architecture
+//!
+//! Each vertical is a [`VerticalConfig`] containing everything needed to instantiate
+//! and register an agent:
+//!
+//! - **Persona** — system prompt defining the agent's identity and behavior
+//! - **Tools** — which Praxis tools are enabled (e.g., coding gets `edit_file`, data gets `bash`)
+//! - **Contract** — Haima outcome-based pricing (price range, success criteria, SLA)
+//! - **Listing** — Spaces marketplace registration data (skills, pricing model, capabilities)
+//! - **Health thresholds** — Autonomic health reporting configuration
+//!
+//! # Usage
+//!
+//! ```rust
+//! use arcan_fleet::{AgentVertical, VerticalConfig};
+//!
+//! let config = VerticalConfig::for_vertical(AgentVertical::Coding);
+//! assert_eq!(config.agent_id(), "life-coding-agent-v1");
+//! assert!(!config.persona().is_empty());
+//! ```
+
+pub mod coding;
+pub mod contracts;
+pub mod data;
+pub mod health;
+pub mod listing;
+pub mod support;
+pub mod vertical;
+
+pub use vertical::{AgentVertical, ToolPermissions, VerticalConfig};
+
+/// Return configs for all three verticals.
+pub fn all_verticals() -> Vec<VerticalConfig> {
+    vec![
+        VerticalConfig::for_vertical(AgentVertical::Coding),
+        VerticalConfig::for_vertical(AgentVertical::DataProcessing),
+        VerticalConfig::for_vertical(AgentVertical::Support),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_verticals_returns_three() {
+        let configs = all_verticals();
+        assert_eq!(configs.len(), 3);
+    }
+
+    #[test]
+    fn each_vertical_has_unique_agent_id() {
+        let configs = all_verticals();
+        let ids: Vec<&str> = configs.iter().map(|c| c.agent_id()).collect();
+        let mut deduped = ids.clone();
+        deduped.sort();
+        deduped.dedup();
+        assert_eq!(ids.len(), deduped.len(), "agent IDs must be unique");
+    }
+
+    #[test]
+    fn each_vertical_has_persona() {
+        for config in all_verticals() {
+            assert!(
+                !config.persona().is_empty(),
+                "{:?} has empty persona",
+                config.vertical
+            );
+        }
+    }
+
+    #[test]
+    fn each_vertical_has_contract() {
+        for config in all_verticals() {
+            let contract = config.contract();
+            assert!(
+                contract.price_floor_micro_credits > 0,
+                "{:?} has zero floor price",
+                config.vertical
+            );
+            assert!(
+                contract.price_floor_micro_credits <= contract.price_ceiling_micro_credits,
+                "{:?} has floor > ceiling",
+                config.vertical
+            );
+        }
+    }
+
+    #[test]
+    fn each_vertical_has_listing() {
+        for config in all_verticals() {
+            let listing = config.listing();
+            assert!(
+                !listing.name.is_empty(),
+                "{:?} has empty listing name",
+                config.vertical
+            );
+            assert!(
+                !listing.skills.is_empty(),
+                "{:?} has no skills",
+                config.vertical
+            );
+        }
+    }
+}

--- a/crates/arcan-fleet/src/listing.rs
+++ b/crates/arcan-fleet/src/listing.rs
@@ -1,0 +1,312 @@
+//! Spaces marketplace listing data for each agent vertical.
+//!
+//! These structs map directly to the `AgentListing` and `AgentSkill` tables
+//! in the Spaces SpacetimeDB module. The bootstrap script converts them into
+//! `register_listing` / `add_skill` reducer calls.
+
+use crate::vertical::AgentVertical;
+use serde::{Deserialize, Serialize};
+
+/// Marketplace listing data for a vertical.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketplaceListing {
+    /// Unique agent identifier (matches `AgentListing.agent_id`).
+    pub agent_id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Description shown in the marketplace.
+    pub description: String,
+    /// Service endpoint URL (where A2A tasks are sent).
+    pub url: String,
+    /// Agent version string.
+    pub version: String,
+    /// Provider organization name.
+    pub provider_name: String,
+    /// Provider URL.
+    pub provider_url: String,
+    /// Documentation URL.
+    pub documentation_url: String,
+    /// Pricing model: "pay_per_use", "free", "subscription", "custom".
+    pub pricing_model: String,
+    /// Price per request in microdollars (for pay_per_use).
+    pub price_per_request_micro: i64,
+    /// Currency code.
+    pub currency: String,
+    /// Listing tier: "free", "premium", "featured".
+    pub tier: String,
+    /// Input MIME types (comma-separated).
+    pub input_modes: String,
+    /// Output MIME types (comma-separated).
+    pub output_modes: String,
+    /// Whether the agent supports streaming responses.
+    pub supports_streaming: bool,
+    /// Skills offered by this agent.
+    pub skills: Vec<AgentSkillData>,
+}
+
+/// A single skill offered by an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSkillData {
+    /// Unique skill ID within this agent.
+    pub skill_id: String,
+    /// Human-readable skill name.
+    pub name: String,
+    /// Skill description.
+    pub description: String,
+    /// Comma-separated tags for discovery.
+    pub tags: String,
+    /// Pipe-separated example use cases.
+    pub examples: String,
+    /// Input MIME types for this skill.
+    pub input_modes: String,
+    /// Output MIME types for this skill.
+    pub output_modes: String,
+}
+
+/// Build the marketplace listing for a vertical.
+pub fn listing_for(vertical: AgentVertical) -> MarketplaceListing {
+    match vertical {
+        AgentVertical::Coding => coding_listing(),
+        AgentVertical::DataProcessing => data_listing(),
+        AgentVertical::Support => support_listing(),
+    }
+}
+
+fn coding_listing() -> MarketplaceListing {
+    MarketplaceListing {
+        agent_id: "life-coding-agent-v1".into(),
+        name: "Life Coding Agent".into(),
+        description: "Expert code review, bug fixing, refactoring, and test writing. \
+            Supports Rust, TypeScript, Python, Go, and more. Outcome-priced per task."
+            .into(),
+        url: "https://fleet.broomva.tech/agents/coding".into(),
+        version: "1.0.0".into(),
+        provider_name: "Broomva Tech".into(),
+        provider_url: "https://broomva.tech".into(),
+        documentation_url: "https://docs.broomva.tech/docs/fleet/coding".into(),
+        pricing_model: "pay_per_use".into(),
+        price_per_request_micro: 2_000_000, // $2.00 base
+        currency: "USD".into(),
+        tier: "premium".into(),
+        input_modes: "text/plain,application/json".into(),
+        output_modes: "text/plain,application/json,text/x-diff".into(),
+        supports_streaming: true,
+        skills: vec![
+            AgentSkillData {
+                skill_id: "code-review".into(),
+                name: "Code Review".into(),
+                description: "Analyze PRs for correctness, style, security, and performance"
+                    .into(),
+                tags: "code,review,pr,quality,security".into(),
+                examples: "Review this PR for security issues|Check code style compliance|Find performance bottlenecks".into(),
+                input_modes: "text/plain,text/x-diff".into(),
+                output_modes: "text/plain,application/json".into(),
+            },
+            AgentSkillData {
+                skill_id: "bug-fix".into(),
+                name: "Bug Fix".into(),
+                description: "Diagnose root causes and implement targeted fixes".into(),
+                tags: "bug,fix,debug,diagnose,patch".into(),
+                examples: "Fix this null pointer exception|Debug why tests fail on CI|Patch this security vulnerability".into(),
+                input_modes: "text/plain,application/json".into(),
+                output_modes: "text/plain,text/x-diff".into(),
+            },
+            AgentSkillData {
+                skill_id: "refactor".into(),
+                name: "Refactoring".into(),
+                description: "Restructure code for clarity, maintainability, and performance"
+                    .into(),
+                tags: "refactor,clean,restructure,optimize".into(),
+                examples: "Extract this into a reusable function|Reduce complexity of this module|Optimize this hot path".into(),
+                input_modes: "text/plain".into(),
+                output_modes: "text/plain,text/x-diff".into(),
+            },
+            AgentSkillData {
+                skill_id: "test-writing".into(),
+                name: "Test Writing".into(),
+                description: "Generate comprehensive unit, integration, and property tests".into(),
+                tags: "test,unit,integration,coverage,tdd".into(),
+                examples: "Write tests for this function|Increase coverage for this module|Add property-based tests".into(),
+                input_modes: "text/plain".into(),
+                output_modes: "text/plain".into(),
+            },
+        ],
+    }
+}
+
+fn data_listing() -> MarketplaceListing {
+    MarketplaceListing {
+        agent_id: "life-data-agent-v1".into(),
+        name: "Life Data Processing Agent".into(),
+        description: "ETL pipelines, data cleaning, transformation, and report generation. \
+            Handles CSV, JSON, SQL, Parquet, and streaming data. Outcome-priced per pipeline run."
+            .into(),
+        url: "https://fleet.broomva.tech/agents/data".into(),
+        version: "1.0.0".into(),
+        provider_name: "Broomva Tech".into(),
+        provider_url: "https://broomva.tech".into(),
+        documentation_url: "https://docs.broomva.tech/docs/fleet/data".into(),
+        pricing_model: "pay_per_use".into(),
+        price_per_request_micro: 5_000_000, // $5.00 base
+        currency: "USD".into(),
+        tier: "premium".into(),
+        input_modes: "text/csv,application/json,application/x-ndjson,text/plain".into(),
+        output_modes: "text/csv,application/json,application/x-ndjson,text/markdown".into(),
+        supports_streaming: true,
+        skills: vec![
+            AgentSkillData {
+                skill_id: "etl-pipeline".into(),
+                name: "ETL Pipeline".into(),
+                description: "Extract, transform, and load data between systems".into(),
+                tags: "etl,pipeline,extract,transform,load,data".into(),
+                examples: "Run this ETL pipeline|Extract data from API and load to CSV|Transform JSON to normalized tables".into(),
+                input_modes: "application/json,text/csv".into(),
+                output_modes: "application/json,text/csv".into(),
+            },
+            AgentSkillData {
+                skill_id: "data-cleaning".into(),
+                name: "Data Cleaning".into(),
+                description: "Detect and fix anomalies, missing values, and format issues".into(),
+                tags: "clean,validate,anomaly,missing,format,quality".into(),
+                examples: "Clean this CSV of duplicates|Fix date format inconsistencies|Fill missing values".into(),
+                input_modes: "text/csv,application/json".into(),
+                output_modes: "text/csv,application/json".into(),
+            },
+            AgentSkillData {
+                skill_id: "report-generation".into(),
+                name: "Report Generation".into(),
+                description: "Produce structured reports with summaries and visualizations".into(),
+                tags: "report,summary,aggregate,statistics,markdown".into(),
+                examples: "Generate a monthly sales report|Summarize this dataset|Create a data quality report".into(),
+                input_modes: "text/csv,application/json".into(),
+                output_modes: "text/markdown,application/json".into(),
+            },
+        ],
+    }
+}
+
+fn support_listing() -> MarketplaceListing {
+    MarketplaceListing {
+        agent_id: "life-support-agent-v1".into(),
+        name: "Life Support Agent".into(),
+        description: "Customer support for ticket triage, FAQ response, and escalation routing. \
+            Knowledge-base-powered with sentiment analysis. Outcome-priced per ticket resolved."
+            .into(),
+        url: "https://fleet.broomva.tech/agents/support".into(),
+        version: "1.0.0".into(),
+        provider_name: "Broomva Tech".into(),
+        provider_url: "https://broomva.tech".into(),
+        documentation_url: "https://docs.broomva.tech/docs/fleet/support".into(),
+        pricing_model: "pay_per_use".into(),
+        price_per_request_micro: 500_000, // $0.50 base
+        currency: "USD".into(),
+        tier: "premium".into(),
+        input_modes: "text/plain,application/json".into(),
+        output_modes: "text/plain,application/json".into(),
+        supports_streaming: true,
+        skills: vec![
+            AgentSkillData {
+                skill_id: "ticket-triage".into(),
+                name: "Ticket Triage".into(),
+                description: "Classify tickets by urgency, category, and routing destination"
+                    .into(),
+                tags: "triage,classify,priority,routing,ticket".into(),
+                examples: "Triage this support ticket|Classify urgency level|Route to appropriate team".into(),
+                input_modes: "text/plain,application/json".into(),
+                output_modes: "application/json".into(),
+            },
+            AgentSkillData {
+                skill_id: "faq-response".into(),
+                name: "FAQ Response".into(),
+                description: "Answer common questions from the knowledge base".into(),
+                tags: "faq,answer,knowledge,help,question".into(),
+                examples: "Answer this customer question|Find relevant documentation|Explain this feature".into(),
+                input_modes: "text/plain".into(),
+                output_modes: "text/plain".into(),
+            },
+            AgentSkillData {
+                skill_id: "escalation".into(),
+                name: "Escalation Routing".into(),
+                description: "Identify and route tickets requiring specialist intervention".into(),
+                tags: "escalate,route,specialist,urgent,critical".into(),
+                examples: "This needs engineering attention|Route to billing team|Escalate security concern".into(),
+                input_modes: "text/plain,application/json".into(),
+                output_modes: "application/json".into(),
+            },
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_listings_valid() {
+        for vertical in [
+            AgentVertical::Coding,
+            AgentVertical::DataProcessing,
+            AgentVertical::Support,
+        ] {
+            let listing = listing_for(vertical);
+            assert!(!listing.agent_id.is_empty());
+            assert!(!listing.name.is_empty());
+            assert!(!listing.description.is_empty());
+            assert!(!listing.url.is_empty());
+            assert!(!listing.skills.is_empty());
+            assert!(listing.price_per_request_micro > 0);
+        }
+    }
+
+    #[test]
+    fn coding_has_four_skills() {
+        let listing = listing_for(AgentVertical::Coding);
+        assert_eq!(listing.skills.len(), 4);
+    }
+
+    #[test]
+    fn data_has_three_skills() {
+        let listing = listing_for(AgentVertical::DataProcessing);
+        assert_eq!(listing.skills.len(), 3);
+    }
+
+    #[test]
+    fn support_has_three_skills() {
+        let listing = listing_for(AgentVertical::Support);
+        assert_eq!(listing.skills.len(), 3);
+    }
+
+    #[test]
+    fn listings_serialize_to_json() {
+        for vertical in [
+            AgentVertical::Coding,
+            AgentVertical::DataProcessing,
+            AgentVertical::Support,
+        ] {
+            let listing = listing_for(vertical);
+            let json = serde_json::to_string_pretty(&listing).unwrap();
+            assert!(json.contains(&listing.agent_id));
+        }
+    }
+
+    #[test]
+    fn skill_ids_unique_within_listing() {
+        for vertical in [
+            AgentVertical::Coding,
+            AgentVertical::DataProcessing,
+            AgentVertical::Support,
+        ] {
+            let listing = listing_for(vertical);
+            let mut ids: Vec<&str> = listing.skills.iter().map(|s| s.skill_id.as_str()).collect();
+            let original_len = ids.len();
+            ids.sort();
+            ids.dedup();
+            assert_eq!(
+                ids.len(),
+                original_len,
+                "duplicate skill IDs in {:?}",
+                vertical
+            );
+        }
+    }
+}

--- a/crates/arcan-fleet/src/support.rs
+++ b/crates/arcan-fleet/src/support.rs
@@ -1,0 +1,98 @@
+//! Support agent vertical — ticket triage, FAQ response, escalation routing.
+//!
+//! This agent has read-only filesystem access and memory tools.
+//! No shell execution or file writing — it reads knowledge bases and responds.
+//! It earns revenue per ticket resolved.
+
+use crate::vertical::{AgentVertical, ToolPermissions, VerticalConfig};
+
+/// Support agent persona.
+const PERSONA: &str = "\
+You are a customer support agent specializing in ticket triage, FAQ response, \
+and escalation routing. You operate within the Life Agent OS ecosystem.\n\
+\n\
+## Core capabilities\n\
+- **Ticket triage**: Classify incoming tickets by urgency, category, and routing\n\
+- **FAQ response**: Answer common questions from the knowledge base\n\
+- **Escalation routing**: Identify tickets requiring human or specialist intervention\n\
+- **Sentiment analysis**: Detect frustrated or urgent customers for priority handling\n\
+- **Resolution tracking**: Record solutions for future knowledge base updates\n\
+\n\
+## Working style\n\
+- Be empathetic and professional — represent the organization well\n\
+- Search the knowledge base thoroughly before composing a response\n\
+- If uncertain, escalate rather than guessing — wrong answers damage trust\n\
+- Keep responses concise and actionable — customers want solutions, not essays\n\
+- Cite specific documentation or resources when available\n\
+- Track resolution patterns to improve future responses via memory\n\
+\n\
+## Triage categories\n\
+- **P0 Critical**: Service outage, data loss, security breach → immediate escalation\n\
+- **P1 High**: Blocking issue, broken workflow → respond within 15 minutes\n\
+- **P2 Medium**: Feature request, non-blocking bug → respond within 1 hour\n\
+- **P3 Low**: General question, documentation request → respond within 4 hours\n\
+\n\
+## Quality standards\n\
+- First-response resolution rate target: >70%\n\
+- Always confirm the customer's issue is understood before offering a solution\n\
+- Include next steps or expected timeline in every response\n\
+- Mark tickets with appropriate labels for analytics";
+
+/// Support agent behavioral rules.
+const RULES: &str = "\
+## Operational rules\n\
+1. Never execute shell commands or modify files — you are read-only\n\
+2. Search the knowledge base before every response (use grep/glob on docs)\n\
+3. Escalate P0/P1 tickets immediately — do not attempt resolution\n\
+4. If the answer isn't in the knowledge base, say so and escalate\n\
+5. Record new solutions in memory for future reference\n\
+6. Never share internal system details, credentials, or architecture with customers\n\
+7. Respond in the customer's language when possible\n\
+\n\
+## Economic rules\n\
+- Bill only when the customer confirms resolution or the ticket is closed\n\
+- Complexity = Simple for FAQ, Standard for investigation, Complex for multi-step\n\
+- Escalated tickets are not billed (the specialist agent handles billing)";
+
+/// Build the support agent configuration.
+pub fn config() -> VerticalConfig {
+    VerticalConfig::new(
+        AgentVertical::Support,
+        "life-support-agent-v1",
+        "Life Support Agent",
+        "Customer support agent for ticket triage, FAQ response, and escalation. \
+         Knowledge-base-powered with sentiment analysis. Outcome-priced per ticket resolved.",
+        PERSONA,
+        RULES,
+        ToolPermissions::support(),
+        12, // max iterations — support is usually quick
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn support_config_valid() {
+        let cfg = config();
+        assert_eq!(cfg.agent_id(), "life-support-agent-v1");
+        assert_eq!(cfg.vertical, AgentVertical::Support);
+        assert_eq!(cfg.max_iterations, 12);
+        assert!(cfg.persona().contains("ticket triage"));
+        assert!(cfg.rules().contains("read-only"));
+    }
+
+    #[test]
+    fn support_is_read_only() {
+        let cfg = config();
+        let tools = cfg.tools.enabled_tools();
+        assert!(!tools.contains(&"bash"));
+        assert!(!tools.contains(&"write_file"));
+        assert!(!tools.contains(&"edit_file"));
+        assert!(tools.contains(&"read_file"));
+        assert!(tools.contains(&"grep"));
+        assert!(tools.contains(&"read_memory"));
+        assert!(tools.contains(&"write_memory")); // memory is allowed
+    }
+}

--- a/crates/arcan-fleet/src/vertical.rs
+++ b/crates/arcan-fleet/src/vertical.rs
@@ -1,0 +1,277 @@
+//! Core types for agent verticals.
+
+use crate::listing::MarketplaceListing;
+use haima_core::outcome::TaskContract;
+use serde::{Deserialize, Serialize};
+
+/// The three production agent verticals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentVertical {
+    /// Code review, bug fixes, refactoring, test writing.
+    Coding,
+    /// ETL pipelines, data cleaning, report generation.
+    DataProcessing,
+    /// Ticket triage, FAQ response, escalation routing.
+    Support,
+}
+
+impl std::fmt::Display for AgentVertical {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Coding => write!(f, "coding"),
+            Self::DataProcessing => write!(f, "data_processing"),
+            Self::Support => write!(f, "support"),
+        }
+    }
+}
+
+/// Which Praxis tools an agent vertical is permitted to use.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolPermissions {
+    pub read_file: bool,
+    pub write_file: bool,
+    pub edit_file: bool,
+    pub list_dir: bool,
+    pub glob: bool,
+    pub grep: bool,
+    pub bash: bool,
+    pub read_memory: bool,
+    pub write_memory: bool,
+}
+
+impl ToolPermissions {
+    /// All tools enabled (coding agent).
+    pub fn full() -> Self {
+        Self {
+            read_file: true,
+            write_file: true,
+            edit_file: true,
+            list_dir: true,
+            glob: true,
+            grep: true,
+            bash: true,
+            read_memory: true,
+            write_memory: true,
+        }
+    }
+
+    /// Read-heavy + bash for pipeline execution (data agent).
+    pub fn data_processing() -> Self {
+        Self {
+            read_file: true,
+            write_file: true,
+            edit_file: false,
+            list_dir: true,
+            glob: true,
+            grep: true,
+            bash: true,
+            read_memory: true,
+            write_memory: true,
+        }
+    }
+
+    /// Read-only filesystem + memory (support agent).
+    pub fn support() -> Self {
+        Self {
+            read_file: true,
+            write_file: false,
+            edit_file: false,
+            list_dir: true,
+            glob: true,
+            grep: true,
+            bash: false,
+            read_memory: true,
+            write_memory: true,
+        }
+    }
+
+    /// Return the list of enabled tool names.
+    pub fn enabled_tools(&self) -> Vec<&'static str> {
+        let mut tools = Vec::new();
+        if self.read_file {
+            tools.push("read_file");
+        }
+        if self.write_file {
+            tools.push("write_file");
+        }
+        if self.edit_file {
+            tools.push("edit_file");
+        }
+        if self.list_dir {
+            tools.push("list_dir");
+        }
+        if self.glob {
+            tools.push("glob");
+        }
+        if self.grep {
+            tools.push("grep");
+        }
+        if self.bash {
+            tools.push("bash");
+        }
+        if self.read_memory {
+            tools.push("read_memory");
+        }
+        if self.write_memory {
+            tools.push("write_memory");
+        }
+        tools
+    }
+}
+
+/// Complete configuration for an agent vertical.
+///
+/// Contains everything needed to instantiate an Arcan orchestrator, register
+/// on the Spaces marketplace, and set up Haima billing.
+#[derive(Debug, Clone)]
+pub struct VerticalConfig {
+    pub vertical: AgentVertical,
+    agent_id: String,
+    name: String,
+    description: String,
+    persona: String,
+    rules: String,
+    pub tools: ToolPermissions,
+    pub max_iterations: u32,
+}
+
+impl VerticalConfig {
+    /// Build the config for a specific vertical.
+    pub fn for_vertical(vertical: AgentVertical) -> Self {
+        match vertical {
+            AgentVertical::Coding => crate::coding::config(),
+            AgentVertical::DataProcessing => crate::data::config(),
+            AgentVertical::Support => crate::support::config(),
+        }
+    }
+
+    /// Stable agent identifier for marketplace registration.
+    pub fn agent_id(&self) -> &str {
+        &self.agent_id
+    }
+
+    /// Human-readable name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Short description for marketplace listing.
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// System prompt (Persona context block).
+    pub fn persona(&self) -> &str {
+        &self.persona
+    }
+
+    /// Behavioral rules (Rules context block).
+    pub fn rules(&self) -> &str {
+        &self.rules
+    }
+
+    /// Build context blocks for the Arcan context compiler.
+    pub fn context_blocks(&self) -> Vec<(arcan_core::context_compiler::ContextBlockKind, String)> {
+        use arcan_core::context_compiler::ContextBlockKind;
+        vec![
+            (ContextBlockKind::Persona, self.persona.clone()),
+            (ContextBlockKind::Rules, self.rules.clone()),
+        ]
+    }
+
+    /// Get the Haima task contract for this vertical.
+    pub fn contract(&self) -> TaskContract {
+        crate::contracts::contract_for(self.vertical)
+    }
+
+    /// Get the Spaces marketplace listing data.
+    pub fn listing(&self) -> MarketplaceListing {
+        crate::listing::listing_for(self.vertical)
+    }
+
+    /// Construct a new VerticalConfig (used by vertical modules).
+    pub(crate) fn new(
+        vertical: AgentVertical,
+        agent_id: impl Into<String>,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        persona: impl Into<String>,
+        rules: impl Into<String>,
+        tools: ToolPermissions,
+        max_iterations: u32,
+    ) -> Self {
+        Self {
+            vertical,
+            agent_id: agent_id.into(),
+            name: name.into(),
+            description: description.into(),
+            persona: persona.into(),
+            rules: rules.into(),
+            tools,
+            max_iterations,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vertical_display() {
+        assert_eq!(AgentVertical::Coding.to_string(), "coding");
+        assert_eq!(AgentVertical::DataProcessing.to_string(), "data_processing");
+        assert_eq!(AgentVertical::Support.to_string(), "support");
+    }
+
+    #[test]
+    fn vertical_serde_roundtrip() {
+        let v = AgentVertical::Coding;
+        let json = serde_json::to_string(&v).unwrap();
+        assert_eq!(json, "\"coding\"");
+        let back: AgentVertical = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn full_permissions_has_all_tools() {
+        let perms = ToolPermissions::full();
+        assert_eq!(perms.enabled_tools().len(), 9);
+    }
+
+    #[test]
+    fn support_permissions_no_write_no_bash() {
+        let perms = ToolPermissions::support();
+        let tools = perms.enabled_tools();
+        assert!(!tools.contains(&"write_file"));
+        assert!(!tools.contains(&"edit_file"));
+        assert!(!tools.contains(&"bash"));
+        assert!(tools.contains(&"read_file"));
+        assert!(tools.contains(&"grep"));
+    }
+
+    #[test]
+    fn data_permissions_no_edit() {
+        let perms = ToolPermissions::data_processing();
+        let tools = perms.enabled_tools();
+        assert!(!tools.contains(&"edit_file"));
+        assert!(tools.contains(&"bash"));
+        assert!(tools.contains(&"write_file"));
+    }
+
+    #[test]
+    fn context_blocks_has_persona_and_rules() {
+        let config = VerticalConfig::for_vertical(AgentVertical::Coding);
+        let blocks = config.context_blocks();
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(
+            blocks[0].0,
+            arcan_core::context_compiler::ContextBlockKind::Persona
+        );
+        assert_eq!(
+            blocks[1].0,
+            arcan_core::context_compiler::ContextBlockKind::Rules
+        );
+    }
+}

--- a/crates/arcan-lago/src/ephemeral.rs
+++ b/crates/arcan-lago/src/ephemeral.rs
@@ -624,6 +624,10 @@ mod tests {
             .append(make_envelope(&session, memory_proposed_event()))
             .await
             .unwrap();
-        assert_eq!(inner.count(), 1, "memory event must persist after full unmark");
+        assert_eq!(
+            inner.count(),
+            1,
+            "memory event must persist after full unmark"
+        );
     }
 }

--- a/crates/arcan-lago/src/ephemeral.rs
+++ b/crates/arcan-lago/src/ephemeral.rs
@@ -49,7 +49,7 @@ use lago_core::{
     session::Session,
 };
 use std::{
-    collections::HashSet,
+    collections::HashMap,
     pin::Pin,
     sync::{Arc, Mutex},
 };
@@ -158,8 +158,13 @@ impl Journal for EphemeralJournal {
 /// [`unmark_ephemeral`]: SessionJournalSelector::unmark_ephemeral
 pub struct SessionJournalSelector {
     inner: Arc<dyn Journal>,
-    /// Sessions whose memory events should be discarded.
-    ephemeral: Mutex<HashSet<String>>,
+    /// Ref-counted set of sessions whose memory events should be discarded.
+    ///
+    /// The `usize` value is the number of outstanding `mark_ephemeral` calls
+    /// for that session ID. An entry is removed when the counter reaches zero,
+    /// which prevents a race where two concurrent callers mark the same session
+    /// and the first `unmark_ephemeral` incorrectly re-enables persistence.
+    ephemeral: Mutex<HashMap<String, usize>>,
 }
 
 impl SessionJournalSelector {
@@ -167,7 +172,7 @@ impl SessionJournalSelector {
     pub fn new(journal: Arc<dyn Journal>) -> Self {
         Self {
             inner: journal,
-            ephemeral: Mutex::new(HashSet::new()),
+            ephemeral: Mutex::new(HashMap::new()),
         }
     }
 
@@ -178,10 +183,12 @@ impl SessionJournalSelector {
     ///
     /// [`unmark_ephemeral`]: Self::unmark_ephemeral
     pub fn mark_ephemeral(&self, session_id: impl AsRef<str>) {
-        self.ephemeral
+        *self
+            .ephemeral
             .lock()
             .unwrap()
-            .insert(session_id.as_ref().to_owned());
+            .entry(session_id.as_ref().to_owned())
+            .or_insert(0) += 1;
     }
 
     /// Deregister `session_id` from the ephemeral set.
@@ -189,12 +196,24 @@ impl SessionJournalSelector {
     /// Typically called after the agent tick completes. Idempotent — does
     /// nothing if the session was not registered.
     pub fn unmark_ephemeral(&self, session_id: impl AsRef<str>) {
-        self.ephemeral.lock().unwrap().remove(session_id.as_ref());
+        let mut map = self.ephemeral.lock().unwrap();
+        if let Some(count) = map.get_mut(session_id.as_ref()) {
+            *count -= 1;
+            if *count == 0 {
+                map.remove(session_id.as_ref());
+            }
+        }
     }
 
     /// Returns `true` if `session_id` is currently registered as ephemeral.
     pub fn is_ephemeral(&self, session_id: &SessionId) -> bool {
-        self.ephemeral.lock().unwrap().contains(session_id.as_str())
+        self.ephemeral
+            .lock()
+            .unwrap()
+            .get(session_id.as_str())
+            .copied()
+            .unwrap_or(0)
+            > 0
     }
 
     /// Returns `true` if the event payload is a memory event that should be
@@ -569,5 +588,42 @@ mod tests {
         selector.append_batch(events).await.unwrap();
         // Only the ToolCallRequested must reach the inner journal.
         assert_eq!(inner.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn selector_ref_counts_concurrent_marks() {
+        // Two concurrent callers both mark the same session as ephemeral.
+        // The session must remain ephemeral until *both* have called unmark.
+        let inner = Arc::new(RecordingJournal::default());
+        let selector = Arc::new(SessionJournalSelector::new(inner.clone()));
+        let session = SessionId::from_string("shared-session");
+
+        // Simulate two concurrent "mark" holders (e.g. two overlapping ticks).
+        selector.mark_ephemeral(session.clone()); // ref-count = 1
+        selector.mark_ephemeral(session.clone()); // ref-count = 2
+
+        // First unmark: ref-count drops to 1 — session is still ephemeral.
+        selector.unmark_ephemeral(&session);
+        assert!(
+            selector.is_ephemeral(&session),
+            "session must still be ephemeral after first unmark (ref-count = 1)"
+        );
+        selector
+            .append(make_envelope(&session, memory_proposed_event()))
+            .await
+            .unwrap();
+        assert_eq!(inner.count(), 0, "memory event must still be discarded");
+
+        // Second unmark: ref-count reaches 0 — session is no longer ephemeral.
+        selector.unmark_ephemeral(&session);
+        assert!(
+            !selector.is_ephemeral(&session),
+            "session must no longer be ephemeral after second unmark (ref-count = 0)"
+        );
+        selector
+            .append(make_envelope(&session, memory_proposed_event()))
+            .await
+            .unwrap();
+        assert_eq!(inner.count(), 1, "memory event must persist after full unmark");
     }
 }

--- a/crates/arcan-lago/src/policy_violation.rs
+++ b/crates/arcan-lago/src/policy_violation.rs
@@ -16,7 +16,7 @@
 
 use aios_protocol::EventKind;
 use lago_core::{BranchId, EventEnvelope, EventId, EventPayload, SessionId};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -72,6 +72,29 @@ impl ViolationType {
     }
 }
 
+// ─── Path redaction helper ────────────────────────────────────────────────────
+
+/// Serialise an `Option<String>` field, redacting absolute paths to their last
+/// component to avoid leaking the full filesystem layout in audit events.
+///
+/// - Absolute path (starts with `/`): serialised as the last path component
+///   only, e.g. `/home/user/.secret/key.pem` → `"key.pem"`.
+/// - Relative path or non-path string: serialised as-is.
+/// - `None`: skipped (the field must also carry `skip_serializing_if`).
+fn serialize_redacted_path<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match value {
+        None => serializer.serialize_none(),
+        Some(s) if s.starts_with('/') => {
+            let last = s.rsplit('/').next().unwrap_or(s.as_str());
+            serializer.serialize_some(last)
+        }
+        Some(s) => serializer.serialize_some(s.as_str()),
+    }
+}
+
 // ─── PolicyViolationData ───────────────────────────────────────────────────
 
 /// Structured payload for a `policy.violation` Lago event.
@@ -86,8 +109,13 @@ pub struct PolicyViolationData {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capability: Option<String>,
     /// The value that triggered the violation (command, path, skill name).
-    /// Sensitive absolute paths are redacted to their last component.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Absolute paths are redacted to their last component before serialisation
+    /// to avoid leaking the full filesystem layout in audit logs.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_redacted_path"
+    )]
     pub attempted_value: Option<String>,
     /// The tier at the time of violation, e.g. `"anonymous"`, `"free"`.
     pub tier: String,
@@ -216,6 +244,67 @@ mod tests {
         let json = serde_json::to_value(&data).unwrap();
         assert_eq!(json["capability"], "exec:cmd:*");
         assert_eq!(json["attempted_value"], "deep-research");
+    }
+
+    // ── Path redaction tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn absolute_path_is_redacted_to_last_component() {
+        let data = PolicyViolationData {
+            violation_type: ViolationType::PathTraversal,
+            capability: None,
+            attempted_value: Some("/home/user/.secret/key.pem".to_string()),
+            tier: "free".to_string(),
+            subject: "user-xyz".to_string(),
+        };
+        let json = serde_json::to_value(&data).unwrap();
+        assert_eq!(
+            json["attempted_value"], "key.pem",
+            "absolute path must be redacted to last component"
+        );
+    }
+
+    #[test]
+    fn relative_path_is_not_redacted() {
+        let data = PolicyViolationData {
+            violation_type: ViolationType::PathTraversal,
+            capability: None,
+            attempted_value: Some("relative/path/file.txt".to_string()),
+            tier: "free".to_string(),
+            subject: "user-xyz".to_string(),
+        };
+        let json = serde_json::to_value(&data).unwrap();
+        assert_eq!(
+            json["attempted_value"], "relative/path/file.txt",
+            "relative paths must be preserved as-is"
+        );
+    }
+
+    #[test]
+    fn non_path_value_is_not_redacted() {
+        let data = PolicyViolationData {
+            violation_type: ViolationType::CommandNotAllowed,
+            capability: None,
+            attempted_value: Some("rm -rf /".to_string()),
+            tier: "anonymous".to_string(),
+            subject: "session-abc".to_string(),
+        };
+        let json = serde_json::to_value(&data).unwrap();
+        // The value starts with 'r', not '/', so no redaction.
+        assert_eq!(json["attempted_value"], "rm -rf /");
+    }
+
+    #[test]
+    fn deeply_nested_absolute_path_is_redacted_to_filename_only() {
+        let data = PolicyViolationData {
+            violation_type: ViolationType::PathTraversal,
+            capability: None,
+            attempted_value: Some("/var/run/arcan/sessions/s-abc/journal.redb".to_string()),
+            tier: "pro".to_string(),
+            subject: "user-def".to_string(),
+        };
+        let json = serde_json::to_value(&data).unwrap();
+        assert_eq!(json["attempted_value"], "journal.redb");
     }
 
     #[test]

--- a/crates/arcan-lago/src/promotion.rs
+++ b/crates/arcan-lago/src/promotion.rs
@@ -1,0 +1,1128 @@
+//! Promotion Gate — policy-gated rule promotion with rollback.
+//!
+//! Phase 2.3 of the self-learning pipeline. Takes `RuleProposal` entries
+//! produced by the consolidation job (Phase 2.2), validates them against
+//! policy, optionally routes through the approval gate, and commits them
+//! as active rules. Supports full rollback via `learning.reverted` events.
+//!
+//! Event types emitted (all `EventPayload::Custom` with `"learning."` prefix):
+//! - `learning.promoted`  — proposal accepted, rule now active
+//! - `learning.rejected`  — proposal explicitly rejected (with reason)
+//! - `learning.reverted`  — previously promoted rule rolled back
+
+use lago_core::event::{EventEnvelope, EventPayload, PolicyDecisionKind};
+use lago_core::id::{BranchId, EventId, SessionId};
+use lago_core::projection::Projection;
+use lago_core::{Journal, LagoError, LagoResult};
+use lago_policy::PolicyEngine;
+use lago_store::BlobStore;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+// ── Event type constants ────────────────────────────────────────────
+
+pub mod event_types {
+    /// Emitted when a rule proposal is promoted to an active rule.
+    pub const LEARNING_PROMOTED: &str = "learning.promoted";
+    /// Emitted when a rule proposal is explicitly rejected.
+    pub const LEARNING_REJECTED: &str = "learning.rejected";
+    /// Emitted when a previously promoted rule is rolled back.
+    pub const LEARNING_REVERTED: &str = "learning.reverted";
+}
+
+// ── Types ───────────────────────────────────────────────────────────
+
+/// What a promoted rule does when it takes effect.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "value")]
+pub enum ProposalAction {
+    /// Inject guidance text into the system prompt's Rules block.
+    AddSystemPromptGuidance(String),
+    /// Add a policy rule to the runtime policy engine.
+    AddPolicyRule {
+        rule_id: String,
+        name: String,
+        priority: u32,
+        condition_json: serde_json::Value,
+        decision: String,
+        explanation: Option<String>,
+    },
+    /// Modify a tool's runtime configuration.
+    ModifyToolConfig {
+        tool_name: String,
+        config_patch: serde_json::Value,
+    },
+}
+
+/// A rule proposal produced by the consolidation job (Phase 2.2).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleProposal {
+    /// Unique identifier for this proposal.
+    pub proposal_id: String,
+    /// Human-readable description of the proposed rule.
+    pub description: String,
+    /// The action to take if this proposal is promoted.
+    pub action: ProposalAction,
+    /// Confidence score from the consolidation job (0.0–1.0).
+    pub confidence: f64,
+    /// Source learning entries that led to this proposal.
+    pub source_learning_ids: Vec<String>,
+    /// Session where the proposal was generated.
+    pub session_id: String,
+}
+
+/// Configuration for the promotion gate.
+#[derive(Debug, Clone)]
+pub struct PromotionConfig {
+    /// If true, proposals below `auto_promote_confidence` require human approval.
+    pub require_human_approval: bool,
+    /// Confidence threshold for automatic promotion (default: 0.95).
+    pub auto_promote_confidence: f64,
+    /// Maximum number of active rules (safety cap, default: 50).
+    pub max_active_rules: usize,
+    /// Cooldown period after a revert before the same proposal can be re-promoted.
+    pub cooldown_after_revert: Duration,
+}
+
+impl Default for PromotionConfig {
+    fn default() -> Self {
+        Self {
+            require_human_approval: true,
+            auto_promote_confidence: 0.95,
+            max_active_rules: 50,
+            cooldown_after_revert: Duration::from_secs(24 * 60 * 60),
+        }
+    }
+}
+
+/// A rule that has been promoted from a proposal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromotedRule {
+    /// Unique ID for this active rule (generated on promotion).
+    pub rule_id: String,
+    /// The proposal that was promoted.
+    pub proposal_id: String,
+    /// Human-readable rule text.
+    pub rule_text: String,
+    /// The action this rule enacts.
+    pub action: ProposalAction,
+    /// Journal sequence number at promotion time.
+    pub promoted_at: u64,
+    /// Whether this rule has been reverted.
+    pub reverted: bool,
+}
+
+/// An event in the promotion audit trail.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromotionEvent {
+    pub event_type: String,
+    pub rule_id: Option<String>,
+    pub proposal_id: String,
+    pub reason: Option<String>,
+    pub timestamp: u64,
+    pub seq: u64,
+}
+
+/// Error types specific to the promotion gate.
+#[derive(Debug, thiserror::Error)]
+pub enum PromotionError {
+    #[error("proposal {0} not found")]
+    ProposalNotFound(String),
+    #[error("rule {0} not found")]
+    RuleNotFound(String),
+    #[error("rule {0} already reverted")]
+    AlreadyReverted(String),
+    #[error("active rule limit reached ({0})")]
+    ActiveRuleLimitReached(usize),
+    #[error("policy conflict: {0}")]
+    PolicyConflict(String),
+    #[error("proposal {0} is in cooldown after revert")]
+    CooldownActive(String),
+    #[error("requires human approval")]
+    RequiresApproval,
+    #[error("lago error: {0}")]
+    Lago(#[from] LagoError),
+}
+
+// ── Active Rule Set Projection ──────────────────────────────────────
+
+/// Projection that rebuilds the set of active promoted rules by folding
+/// over `learning.promoted` and `learning.reverted` events.
+#[derive(Debug, Default, Clone)]
+pub struct ActiveRuleSet {
+    rules: Vec<PromotedRule>,
+    history: Vec<PromotionEvent>,
+    /// Tracks reverted proposal IDs with their revert timestamp (micros).
+    reverted_proposals: HashMap<String, u64>,
+}
+
+impl ActiveRuleSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get all currently active (non-reverted) rules.
+    pub fn active_rules(&self) -> Vec<&PromotedRule> {
+        self.rules.iter().filter(|r| !r.reverted).collect()
+    }
+
+    /// Count of active (non-reverted) rules.
+    pub fn active_count(&self) -> usize {
+        self.rules.iter().filter(|r| !r.reverted).count()
+    }
+
+    /// Get the full promotion history (all events).
+    pub fn history(&self) -> &[PromotionEvent] {
+        &self.history
+    }
+
+    /// Check if a proposal was recently reverted (within cooldown).
+    pub fn is_in_cooldown(&self, proposal_id: &str, cooldown: Duration, now_micros: u64) -> bool {
+        if let Some(&revert_time) = self.reverted_proposals.get(proposal_id) {
+            let cooldown_micros = cooldown.as_micros() as u64;
+            return now_micros.saturating_sub(revert_time) < cooldown_micros;
+        }
+        false
+    }
+
+    /// Find a promoted rule by rule_id.
+    pub fn find_rule(&self, rule_id: &str) -> Option<&PromotedRule> {
+        self.rules.iter().find(|r| r.rule_id == rule_id)
+    }
+
+    /// Fold a single event into the projection.
+    pub fn fold(&mut self, event: &EventEnvelope) {
+        if let EventPayload::Custom {
+            ref event_type,
+            ref data,
+        } = event.payload
+        {
+            match event_type.as_str() {
+                event_types::LEARNING_PROMOTED => {
+                    if let (Some(rule_id), Some(proposal_id), Some(rule_text)) = (
+                        data.get("rule_id").and_then(|v| v.as_str()),
+                        data.get("proposal_id").and_then(|v| v.as_str()),
+                        data.get("rule_text").and_then(|v| v.as_str()),
+                    ) {
+                        let action: Option<ProposalAction> = data
+                            .get("action")
+                            .and_then(|v| serde_json::from_value(v.clone()).ok());
+
+                        self.rules.push(PromotedRule {
+                            rule_id: rule_id.to_string(),
+                            proposal_id: proposal_id.to_string(),
+                            rule_text: rule_text.to_string(),
+                            action: action.unwrap_or(ProposalAction::AddSystemPromptGuidance(
+                                rule_text.to_string(),
+                            )),
+                            promoted_at: event.seq,
+                            reverted: false,
+                        });
+
+                        self.history.push(PromotionEvent {
+                            event_type: event_types::LEARNING_PROMOTED.to_string(),
+                            rule_id: Some(rule_id.to_string()),
+                            proposal_id: proposal_id.to_string(),
+                            reason: None,
+                            timestamp: event.timestamp,
+                            seq: event.seq,
+                        });
+                    }
+                }
+                event_types::LEARNING_REJECTED => {
+                    if let Some(proposal_id) = data.get("proposal_id").and_then(|v| v.as_str()) {
+                        self.history.push(PromotionEvent {
+                            event_type: event_types::LEARNING_REJECTED.to_string(),
+                            rule_id: None,
+                            proposal_id: proposal_id.to_string(),
+                            reason: data
+                                .get("reason")
+                                .and_then(|v| v.as_str())
+                                .map(String::from),
+                            timestamp: event.timestamp,
+                            seq: event.seq,
+                        });
+                    }
+                }
+                event_types::LEARNING_REVERTED => {
+                    if let Some(rule_id) = data.get("rule_id").and_then(|v| v.as_str()) {
+                        // Mark the rule as reverted
+                        for rule in &mut self.rules {
+                            if rule.rule_id == rule_id {
+                                rule.reverted = true;
+                                // Track revert for cooldown
+                                self.reverted_proposals
+                                    .insert(rule.proposal_id.clone(), event.timestamp);
+                            }
+                        }
+
+                        self.history.push(PromotionEvent {
+                            event_type: event_types::LEARNING_REVERTED.to_string(),
+                            rule_id: Some(rule_id.to_string()),
+                            proposal_id: data
+                                .get("proposal_id")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            reason: data
+                                .get("reason")
+                                .and_then(|v| v.as_str())
+                                .map(String::from),
+                            timestamp: event.timestamp,
+                            seq: event.seq,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Projection for ActiveRuleSet {
+    fn on_event(&mut self, event: &EventEnvelope) -> LagoResult<()> {
+        self.fold(event);
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "arcan::active_rules"
+    }
+}
+
+// ── Promotion Gate ──────────────────────────────────────────────────
+
+/// Policy-gated promotion mechanism for rule proposals.
+///
+/// Takes proposals from the consolidation job, validates against policy,
+/// optionally requires human approval, commits as active rules, and
+/// supports full rollback.
+pub struct PromotionGate {
+    journal: Arc<dyn Journal>,
+    blob_store: Arc<BlobStore>,
+    policy: Arc<Mutex<PolicyEngine>>,
+    config: PromotionConfig,
+    session_id: SessionId,
+    branch_id: BranchId,
+    /// Local projection rebuilt from events.
+    rule_set: Mutex<ActiveRuleSet>,
+}
+
+impl PromotionGate {
+    pub fn new(
+        journal: Arc<dyn Journal>,
+        blob_store: Arc<BlobStore>,
+        policy: Arc<Mutex<PolicyEngine>>,
+        config: PromotionConfig,
+        session_id: SessionId,
+        branch_id: BranchId,
+    ) -> Self {
+        Self {
+            journal,
+            blob_store,
+            policy,
+            config,
+            session_id,
+            branch_id,
+            rule_set: Mutex::new(ActiveRuleSet::new()),
+        }
+    }
+
+    /// Rebuild the projection by replaying all learning.* events from the journal.
+    pub async fn rebuild_projection(&self) -> Result<(), PromotionError> {
+        let query = lago_core::journal::EventQuery::default().session(self.session_id.clone());
+        let events = self.journal.read(query).await?;
+
+        let mut rule_set = self
+            .rule_set
+            .lock()
+            .map_err(|e| LagoError::Internal(format!("lock poisoned: {e}")))?;
+        *rule_set = ActiveRuleSet::new();
+        for event in &events {
+            rule_set.fold(event);
+        }
+        Ok(())
+    }
+
+    /// Promote a rule proposal to an active rule.
+    ///
+    /// Checks policy compatibility, enforces limits, and optionally
+    /// requires human approval based on confidence threshold.
+    pub async fn promote(&self, proposal: &RuleProposal) -> Result<PromotedRule, PromotionError> {
+        let now_micros = EventEnvelope::now_micros();
+
+        // Check cooldown
+        {
+            let rule_set = self
+                .rule_set
+                .lock()
+                .map_err(|e| LagoError::Internal(format!("lock poisoned: {e}")))?;
+
+            if rule_set.is_in_cooldown(
+                &proposal.proposal_id,
+                self.config.cooldown_after_revert,
+                now_micros,
+            ) {
+                return Err(PromotionError::CooldownActive(
+                    proposal.proposal_id.clone(),
+                ));
+            }
+
+            // Check active rule limit
+            if rule_set.active_count() >= self.config.max_active_rules {
+                return Err(PromotionError::ActiveRuleLimitReached(
+                    self.config.max_active_rules,
+                ));
+            }
+        }
+
+        // Policy conflict detection for AddPolicyRule actions
+        if let ProposalAction::AddPolicyRule {
+            ref condition_json,
+            ref decision,
+            ..
+        } = proposal.action
+        {
+            self.check_policy_conflict(condition_json, decision)?;
+        }
+
+        // Approval routing
+        let needs_approval = self.config.require_human_approval
+            && proposal.confidence < self.config.auto_promote_confidence;
+        if needs_approval {
+            return Err(PromotionError::RequiresApproval);
+        }
+
+        // Generate rule ID and store rule content in blob store
+        let rule_id = format!("rule-{}", uuid::Uuid::new_v4());
+        let rule_content = serde_json::to_vec(proposal)
+            .map_err(|e| LagoError::Internal(format!("serialization failed: {e}")))?;
+        let _blob_hash = self.blob_store.put(&rule_content)?;
+
+        // Build the promoted rule
+        let promoted = PromotedRule {
+            rule_id: rule_id.clone(),
+            proposal_id: proposal.proposal_id.clone(),
+            rule_text: proposal.description.clone(),
+            action: proposal.action.clone(),
+            promoted_at: 0, // Will be set by journal seq
+            reverted: false,
+        };
+
+        // Emit learning.promoted event
+        let event = build_learning_event(
+            &self.session_id,
+            &self.branch_id,
+            event_types::LEARNING_PROMOTED,
+            serde_json::json!({
+                "rule_id": rule_id,
+                "proposal_id": proposal.proposal_id,
+                "rule_text": proposal.description,
+                "action": proposal.action,
+                "confidence": proposal.confidence,
+                "source_learning_ids": proposal.source_learning_ids,
+            }),
+        );
+        let seq = self.journal.append(event).await?;
+
+        // Update local projection
+        let mut rule_set = self
+            .rule_set
+            .lock()
+            .map_err(|e| LagoError::Internal(format!("lock poisoned: {e}")))?;
+
+        let mut promoted_with_seq = promoted;
+        promoted_with_seq.promoted_at = seq.into();
+        rule_set.rules.push(promoted_with_seq.clone());
+        rule_set.history.push(PromotionEvent {
+            event_type: event_types::LEARNING_PROMOTED.to_string(),
+            rule_id: Some(rule_id),
+            proposal_id: proposal.proposal_id.clone(),
+            reason: None,
+            timestamp: now_micros,
+            seq: seq.into(),
+        });
+
+        Ok(promoted_with_seq)
+    }
+
+    /// Reject a rule proposal with a reason.
+    pub async fn reject(
+        &self,
+        proposal_id: &str,
+        reason: &str,
+    ) -> Result<(), PromotionError> {
+        let now_micros = EventEnvelope::now_micros();
+
+        let event = build_learning_event(
+            &self.session_id,
+            &self.branch_id,
+            event_types::LEARNING_REJECTED,
+            serde_json::json!({
+                "proposal_id": proposal_id,
+                "reason": reason,
+            }),
+        );
+        let seq = self.journal.append(event).await?;
+
+        // Update local projection
+        let mut rule_set = self
+            .rule_set
+            .lock()
+            .map_err(|e| LagoError::Internal(format!("lock poisoned: {e}")))?;
+
+        rule_set.history.push(PromotionEvent {
+            event_type: event_types::LEARNING_REJECTED.to_string(),
+            rule_id: None,
+            proposal_id: proposal_id.to_string(),
+            reason: Some(reason.to_string()),
+            timestamp: now_micros,
+            seq: seq.into(),
+        });
+
+        Ok(())
+    }
+
+    /// Revert a previously promoted rule.
+    pub async fn revert(
+        &self,
+        rule_id: &str,
+        reason: &str,
+    ) -> Result<(), PromotionError> {
+        let now_micros = EventEnvelope::now_micros();
+
+        // Find the rule and get its proposal_id
+        let proposal_id = {
+            let rule_set = self
+                .rule_set
+                .lock()
+                .map_err(|e| LagoError::Internal(format!("lock poisoned: {e}")))?;
+
+            let rule = rule_set
+                .find_rule(rule_id)
+                .ok_or_else(|| PromotionError::RuleNotFound(rule_id.to_string()))?;
+
+            if rule.reverted {
+                return Err(PromotionError::AlreadyReverted(rule_id.to_string()));
+            }
+
+            rule.proposal_id.clone()
+        };
+
+        let event = build_learning_event(
+            &self.session_id,
+            &self.branch_id,
+            event_types::LEARNING_REVERTED,
+            serde_json::json!({
+                "rule_id": rule_id,
+                "proposal_id": proposal_id,
+                "reason": reason,
+            }),
+        );
+        let seq = self.journal.append(event).await?;
+
+        // Update local projection
+        let mut rule_set = self
+            .rule_set
+            .lock()
+            .map_err(|e| LagoError::Internal(format!("lock poisoned: {e}")))?;
+
+        for rule in &mut rule_set.rules {
+            if rule.rule_id == rule_id {
+                rule.reverted = true;
+                rule_set
+                    .reverted_proposals
+                    .insert(rule.proposal_id.clone(), now_micros);
+            }
+        }
+
+        rule_set.history.push(PromotionEvent {
+            event_type: event_types::LEARNING_REVERTED.to_string(),
+            rule_id: Some(rule_id.to_string()),
+            proposal_id,
+            reason: Some(reason.to_string()),
+            timestamp: now_micros,
+            seq: seq.into(),
+        });
+
+        Ok(())
+    }
+
+    /// Get the current set of active (non-reverted) rules.
+    pub fn active_rules(&self) -> Result<Vec<PromotedRule>, PromotionError> {
+        let rule_set = self
+            .rule_set
+            .lock()
+            .map_err(|e| LagoError::Internal(format!("lock poisoned: {e}")))?;
+
+        Ok(rule_set
+            .active_rules()
+            .into_iter()
+            .cloned()
+            .collect())
+    }
+
+    /// Get the full promotion history (audit trail).
+    pub fn promotion_history(&self) -> Result<Vec<PromotionEvent>, PromotionError> {
+        let rule_set = self
+            .rule_set
+            .lock()
+            .map_err(|e| LagoError::Internal(format!("lock poisoned: {e}")))?;
+
+        Ok(rule_set.history().to_vec())
+    }
+
+    /// Check whether a proposed policy rule conflicts with existing rules.
+    fn check_policy_conflict(
+        &self,
+        condition_json: &serde_json::Value,
+        decision: &str,
+    ) -> Result<(), PromotionError> {
+        let policy = self
+            .policy
+            .lock()
+            .map_err(|e| LagoError::Internal(format!("policy lock poisoned: {e}")))?;
+
+        // Parse the proposed condition to check for direct contradictions
+        let proposed_condition: Result<lago_policy::MatchCondition, _> =
+            serde_json::from_value(condition_json.clone());
+
+        let Ok(proposed) = proposed_condition else {
+            return Err(PromotionError::PolicyConflict(
+                "invalid condition format".to_string(),
+            ));
+        };
+
+        // Check for contradictions: same condition with opposite decision
+        let proposed_decision = match decision {
+            "allow" | "Allow" => PolicyDecisionKind::Allow,
+            "deny" | "Deny" => PolicyDecisionKind::Deny,
+            "require_approval" | "RequireApproval" => PolicyDecisionKind::RequireApproval,
+            other => {
+                return Err(PromotionError::PolicyConflict(format!(
+                    "unknown decision kind: {other}"
+                )))
+            }
+        };
+
+        // Simple conflict detection: if any existing rule has the same
+        // serialized condition but opposite decision, flag it.
+        for existing in policy.rules() {
+            let existing_json = serde_json::to_value(&existing.condition).unwrap_or_default();
+            let proposed_json = serde_json::to_value(&proposed).unwrap_or_default();
+
+            if existing_json == proposed_json && existing.decision != proposed_decision {
+                return Err(PromotionError::PolicyConflict(format!(
+                    "contradicts existing rule '{}' ({}): same condition, different decision",
+                    existing.name, existing.id
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/// Build a Lago `EventEnvelope` for a learning event.
+fn build_learning_event(
+    session_id: &SessionId,
+    branch_id: &BranchId,
+    event_type: &str,
+    data: serde_json::Value,
+) -> EventEnvelope {
+    EventEnvelope {
+        event_id: EventId::new(),
+        session_id: session_id.clone(),
+        branch_id: branch_id.clone(),
+        run_id: None,
+        seq: 0, // Auto-assigned by journal
+        timestamp: EventEnvelope::now_micros(),
+        parent_id: None,
+        payload: EventPayload::Custom {
+            event_type: event_type.to_string(),
+            data,
+        },
+        metadata: HashMap::new(),
+        schema_version: 1,
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lago_core::id::*;
+
+    fn make_custom_event(
+        event_type: &str,
+        data: serde_json::Value,
+        seq: u64,
+        timestamp: u64,
+    ) -> EventEnvelope {
+        EventEnvelope {
+            event_id: EventId::new(),
+            session_id: SessionId::from_string("test"),
+            branch_id: BranchId::from_string("main"),
+            run_id: None,
+            seq,
+            timestamp,
+            parent_id: None,
+            payload: EventPayload::Custom {
+                event_type: event_type.to_string(),
+                data,
+            },
+            metadata: HashMap::new(),
+            schema_version: 1,
+        }
+    }
+
+    fn sample_proposal(id: &str, confidence: f64) -> RuleProposal {
+        RuleProposal {
+            proposal_id: id.to_string(),
+            description: format!("Test rule from proposal {id}"),
+            action: ProposalAction::AddSystemPromptGuidance(
+                "Always check file permissions before writing".to_string(),
+            ),
+            confidence,
+            source_learning_ids: vec!["learn-1".to_string()],
+            session_id: "sess-1".to_string(),
+        }
+    }
+
+    fn sample_policy_proposal(id: &str, confidence: f64) -> RuleProposal {
+        RuleProposal {
+            proposal_id: id.to_string(),
+            description: "Deny shell access".to_string(),
+            action: ProposalAction::AddPolicyRule {
+                rule_id: format!("pr-{id}"),
+                name: "deny shell".to_string(),
+                priority: 10,
+                condition_json: serde_json::json!({"type": "ToolName", "value": "exec_shell"}),
+                decision: "Deny".to_string(),
+                explanation: Some("shell access denied by learning".to_string()),
+            },
+            confidence,
+            source_learning_ids: vec!["learn-2".to_string()],
+            session_id: "sess-1".to_string(),
+        }
+    }
+
+    // ── Projection tests ────────────────────────────────────────────
+
+    #[test]
+    fn projection_promotes_rule() {
+        let mut proj = ActiveRuleSet::new();
+
+        proj.fold(&make_custom_event(
+            event_types::LEARNING_PROMOTED,
+            serde_json::json!({
+                "rule_id": "r1",
+                "proposal_id": "p1",
+                "rule_text": "Always verify permissions",
+                "action": {"type": "AddSystemPromptGuidance", "value": "Always verify permissions"},
+            }),
+            1,
+            1000,
+        ));
+
+        assert_eq!(proj.active_count(), 1);
+        let active = proj.active_rules();
+        assert_eq!(active[0].rule_id, "r1");
+        assert_eq!(active[0].proposal_id, "p1");
+        assert!(!active[0].reverted);
+    }
+
+    #[test]
+    fn projection_rejects_proposal() {
+        let mut proj = ActiveRuleSet::new();
+
+        proj.fold(&make_custom_event(
+            event_types::LEARNING_REJECTED,
+            serde_json::json!({
+                "proposal_id": "p2",
+                "reason": "too risky",
+            }),
+            1,
+            1000,
+        ));
+
+        // Rejected proposals don't appear in active rules
+        assert_eq!(proj.active_count(), 0);
+        // But they show up in history
+        assert_eq!(proj.history().len(), 1);
+        assert_eq!(proj.history()[0].event_type, event_types::LEARNING_REJECTED);
+        assert_eq!(proj.history()[0].reason.as_deref(), Some("too risky"));
+    }
+
+    #[test]
+    fn projection_reverts_promoted_rule() {
+        let mut proj = ActiveRuleSet::new();
+
+        // Promote
+        proj.fold(&make_custom_event(
+            event_types::LEARNING_PROMOTED,
+            serde_json::json!({
+                "rule_id": "r1",
+                "proposal_id": "p1",
+                "rule_text": "Check perms",
+                "action": {"type": "AddSystemPromptGuidance", "value": "Check perms"},
+            }),
+            1,
+            1000,
+        ));
+        assert_eq!(proj.active_count(), 1);
+
+        // Revert
+        proj.fold(&make_custom_event(
+            event_types::LEARNING_REVERTED,
+            serde_json::json!({
+                "rule_id": "r1",
+                "proposal_id": "p1",
+                "reason": "caused regressions",
+            }),
+            2,
+            2000,
+        ));
+
+        assert_eq!(proj.active_count(), 0);
+        assert_eq!(proj.history().len(), 2);
+    }
+
+    #[test]
+    fn projection_cooldown_after_revert() {
+        let mut proj = ActiveRuleSet::new();
+
+        // Promote and revert
+        proj.fold(&make_custom_event(
+            event_types::LEARNING_PROMOTED,
+            serde_json::json!({
+                "rule_id": "r1",
+                "proposal_id": "p1",
+                "rule_text": "Check perms",
+            }),
+            1,
+            1_000_000,
+        ));
+        proj.fold(&make_custom_event(
+            event_types::LEARNING_REVERTED,
+            serde_json::json!({
+                "rule_id": "r1",
+                "proposal_id": "p1",
+                "reason": "bad rule",
+            }),
+            2,
+            2_000_000,
+        ));
+
+        // Immediately after revert: still in cooldown
+        let cooldown = Duration::from_secs(3600); // 1 hour
+        assert!(proj.is_in_cooldown("p1", cooldown, 2_500_000));
+
+        // After cooldown expires: no longer in cooldown
+        let far_future = 2_000_000 + 3_600_000_001; // revert_time + 1h + 1μs
+        assert!(!proj.is_in_cooldown("p1", cooldown, far_future));
+
+        // Unrelated proposal: never in cooldown
+        assert!(!proj.is_in_cooldown("p999", cooldown, 2_500_000));
+    }
+
+    #[test]
+    fn projection_ignores_unrelated_events() {
+        let mut proj = ActiveRuleSet::new();
+
+        proj.fold(&make_custom_event(
+            "skill.activated",
+            serde_json::json!({"name": "test"}),
+            1,
+            1000,
+        ));
+
+        assert_eq!(proj.active_count(), 0);
+        assert!(proj.history().is_empty());
+    }
+
+    #[test]
+    fn projection_multiple_rules_active() {
+        let mut proj = ActiveRuleSet::new();
+
+        for i in 0..5 {
+            proj.fold(&make_custom_event(
+                event_types::LEARNING_PROMOTED,
+                serde_json::json!({
+                    "rule_id": format!("r{i}"),
+                    "proposal_id": format!("p{i}"),
+                    "rule_text": format!("Rule {i}"),
+                }),
+                i as u64,
+                (i * 1000) as u64,
+            ));
+        }
+
+        assert_eq!(proj.active_count(), 5);
+
+        // Revert middle rule
+        proj.fold(&make_custom_event(
+            event_types::LEARNING_REVERTED,
+            serde_json::json!({
+                "rule_id": "r2",
+                "proposal_id": "p2",
+                "reason": "not useful",
+            }),
+            5,
+            5000,
+        ));
+
+        assert_eq!(proj.active_count(), 4);
+        assert!(proj.find_rule("r2").unwrap().reverted);
+        assert!(!proj.find_rule("r3").unwrap().reverted);
+    }
+
+    #[test]
+    fn projection_name() {
+        let proj = ActiveRuleSet::new();
+        assert_eq!(proj.name(), "arcan::active_rules");
+    }
+
+    // ── Serialization tests ─────────────────────────────────────────
+
+    #[test]
+    fn proposal_action_serialization_roundtrip() {
+        let actions = vec![
+            ProposalAction::AddSystemPromptGuidance("Check perms".to_string()),
+            ProposalAction::AddPolicyRule {
+                rule_id: "r1".to_string(),
+                name: "deny shell".to_string(),
+                priority: 10,
+                condition_json: serde_json::json!({"type": "ToolName", "value": "exec_shell"}),
+                decision: "Deny".to_string(),
+                explanation: Some("no shell".to_string()),
+            },
+            ProposalAction::ModifyToolConfig {
+                tool_name: "bash".to_string(),
+                config_patch: serde_json::json!({"timeout_ms": 5000}),
+            },
+        ];
+
+        for action in &actions {
+            let json = serde_json::to_string(action).unwrap();
+            let back: ProposalAction = serde_json::from_str(&json).unwrap();
+            assert_eq!(&back, action);
+        }
+    }
+
+    #[test]
+    fn rule_proposal_serialization() {
+        let proposal = sample_proposal("p1", 0.85);
+        let json = serde_json::to_string(&proposal).unwrap();
+        let back: RuleProposal = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.proposal_id, "p1");
+        assert_eq!(back.confidence, 0.85);
+    }
+
+    // ── Gate integration tests (async, with real journal) ───────────
+
+    async fn setup_gate(config: PromotionConfig) -> PromotionGate {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = Arc::new(
+            lago_journal::RedbJournal::open(dir.path().join("test.redb")).unwrap(),
+        );
+        let blob_store = Arc::new(
+            BlobStore::from_path(dir.path().join("blobs")).unwrap(),
+        );
+        let policy = Arc::new(Mutex::new(PolicyEngine::new()));
+
+        // Create session
+        let session = lago_core::Session {
+            session_id: SessionId::from_string("sess-1"),
+            config: lago_core::session::SessionConfig::new("test"),
+            created_at: 0,
+            branches: vec![],
+        };
+        journal.put_session(session).await.unwrap();
+
+        PromotionGate::new(
+            journal,
+            blob_store,
+            policy,
+            config,
+            SessionId::from_string("sess-1"),
+            BranchId::from_string("main"),
+        )
+    }
+
+    #[tokio::test]
+    async fn gate_promote_creates_active_rule() {
+        let gate = setup_gate(PromotionConfig {
+            require_human_approval: false,
+            auto_promote_confidence: 0.5,
+            ..Default::default()
+        })
+        .await;
+
+        let proposal = sample_proposal("p1", 0.9);
+        let promoted = gate.promote(&proposal).await.unwrap();
+
+        assert_eq!(promoted.proposal_id, "p1");
+        assert!(!promoted.reverted);
+
+        let active = gate.active_rules().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].proposal_id, "p1");
+    }
+
+    #[tokio::test]
+    async fn gate_reject_emits_event() {
+        let gate = setup_gate(PromotionConfig::default()).await;
+
+        gate.reject("p1", "not useful").await.unwrap();
+
+        let history = gate.promotion_history().unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].event_type, event_types::LEARNING_REJECTED);
+        assert_eq!(history[0].reason.as_deref(), Some("not useful"));
+
+        // No active rules
+        assert!(gate.active_rules().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn gate_revert_removes_from_active() {
+        let gate = setup_gate(PromotionConfig {
+            require_human_approval: false,
+            auto_promote_confidence: 0.5,
+            ..Default::default()
+        })
+        .await;
+
+        let proposal = sample_proposal("p1", 0.9);
+        let promoted = gate.promote(&proposal).await.unwrap();
+
+        // Revert it
+        gate.revert(&promoted.rule_id, "caused regressions")
+            .await
+            .unwrap();
+
+        assert!(gate.active_rules().unwrap().is_empty());
+
+        let history = gate.promotion_history().unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[1].event_type, event_types::LEARNING_REVERTED);
+    }
+
+    #[tokio::test]
+    async fn gate_auto_promote_above_threshold() {
+        let gate = setup_gate(PromotionConfig {
+            require_human_approval: true,
+            auto_promote_confidence: 0.90,
+            ..Default::default()
+        })
+        .await;
+
+        // High confidence → auto-promote even with require_human_approval
+        let proposal = sample_proposal("p1", 0.95);
+        let result = gate.promote(&proposal).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn gate_requires_approval_below_threshold() {
+        let gate = setup_gate(PromotionConfig {
+            require_human_approval: true,
+            auto_promote_confidence: 0.95,
+            ..Default::default()
+        })
+        .await;
+
+        // Low confidence + require_human_approval → RequiresApproval error
+        let proposal = sample_proposal("p1", 0.80);
+        let result = gate.promote(&proposal).await;
+        assert!(matches!(result, Err(PromotionError::RequiresApproval)));
+    }
+
+    #[tokio::test]
+    async fn gate_enforces_max_active_rules() {
+        let gate = setup_gate(PromotionConfig {
+            require_human_approval: false,
+            auto_promote_confidence: 0.5,
+            max_active_rules: 3,
+            ..Default::default()
+        })
+        .await;
+
+        // Fill up to the limit
+        for i in 0..3 {
+            let proposal = sample_proposal(&format!("p{i}"), 0.9);
+            gate.promote(&proposal).await.unwrap();
+        }
+
+        // Fourth should fail
+        let proposal = sample_proposal("p3", 0.9);
+        let result = gate.promote(&proposal).await;
+        assert!(matches!(
+            result,
+            Err(PromotionError::ActiveRuleLimitReached(3))
+        ));
+    }
+
+    #[tokio::test]
+    async fn gate_policy_conflict_detection() {
+        let gate = setup_gate(PromotionConfig {
+            require_human_approval: false,
+            auto_promote_confidence: 0.5,
+            ..Default::default()
+        })
+        .await;
+
+        // Add an existing rule to the policy engine
+        {
+            let mut policy = gate.policy.lock().unwrap();
+            policy.add_rule(lago_policy::Rule {
+                id: "existing-1".to_string(),
+                name: "allow shell".to_string(),
+                priority: 10,
+                condition: lago_policy::MatchCondition::ToolName("exec_shell".to_string()),
+                decision: PolicyDecisionKind::Allow,
+                explanation: None,
+                required_sandbox: None,
+            });
+        }
+
+        // Propose a contradicting rule (same condition, Deny vs Allow)
+        let proposal = sample_policy_proposal("conflict-1", 0.99);
+        let result = gate.promote(&proposal).await;
+        assert!(matches!(result, Err(PromotionError::PolicyConflict(_))));
+    }
+
+    #[tokio::test]
+    async fn gate_revert_nonexistent_rule_fails() {
+        let gate = setup_gate(PromotionConfig::default()).await;
+
+        let result = gate.revert("nonexistent", "test").await;
+        assert!(matches!(result, Err(PromotionError::RuleNotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn gate_double_revert_fails() {
+        let gate = setup_gate(PromotionConfig {
+            require_human_approval: false,
+            auto_promote_confidence: 0.5,
+            ..Default::default()
+        })
+        .await;
+
+        let proposal = sample_proposal("p1", 0.9);
+        let promoted = gate.promote(&proposal).await.unwrap();
+
+        gate.revert(&promoted.rule_id, "first revert")
+            .await
+            .unwrap();
+
+        let result = gate.revert(&promoted.rule_id, "second revert").await;
+        assert!(matches!(result, Err(PromotionError::AlreadyReverted(_))));
+    }
+}

--- a/crates/arcan-lago/src/retention.rs
+++ b/crates/arcan-lago/src/retention.rs
@@ -553,20 +553,19 @@ impl Journal for FreeTierJournal {
     ) -> Pin<Box<dyn std::future::Future<Output = LagoResult<EventStream>> + Send + '_>> {
         Box::pin(async move {
             use tokio_stream::StreamExt as _;
-            let mut raw = self.inner.stream(session_id, branch_id, after_seq).await?;
-            let mut filtered: Vec<LagoResult<EventEnvelope>> = Vec::new();
-            while let Some(item) = raw.next().await {
-                match &item {
-                    Ok(e) if Self::is_expired(e) => {
-                        tracing::trace!(
-                            event_id = %e.event_id,
-                            "retention: filtering expired event from stream"
-                        );
-                    }
-                    _ => filtered.push(item),
+            let raw = self.inner.stream(session_id, branch_id, after_seq).await?;
+            // Lazily filter expired events without buffering the full stream.
+            let filtered = raw.filter(|item| match item {
+                Ok(e) if Self::is_expired(e) => {
+                    tracing::trace!(
+                        event_id = %e.event_id,
+                        "retention: filtering expired event from stream"
+                    );
+                    false
                 }
-            }
-            Ok(Box::pin(tokio_stream::iter(filtered)) as EventStream)
+                _ => true,
+            });
+            Ok(Box::pin(filtered) as EventStream)
         })
     }
 

--- a/crates/arcan-provider-bubblewrap/Cargo.toml
+++ b/crates/arcan-provider-bubblewrap/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "arcan-provider-bubblewrap"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SandboxProvider implementation using bubblewrap (bwrap) with LocalCommandRunner fallback"
+
+[lints]
+workspace = true
+
+[dependencies]
+arcan-sandbox.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { version = "1", features = ["process", "fs", "rt", "macros", "rt-multi-thread", "time"] }
+uuid.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/arcan-provider-bubblewrap/src/lib.rs
+++ b/crates/arcan-provider-bubblewrap/src/lib.rs
@@ -1,0 +1,609 @@
+//! `arcan-provider-bubblewrap` — [`SandboxProvider`] implementation wrapping
+//! the [`bwrap`](https://github.com/containers/bubblewrap) binary with a plain
+//! subprocess fallback.
+//!
+//! # Backend selection
+//!
+//! At construction time the provider probes `PATH` for the `bwrap` binary.
+//! If found, every [`run`](BubblewrapProvider::run) call isolates the command
+//! inside a minimal bubblewrap namespace. If `bwrap` is absent the provider
+//! falls back to a plain Tokio [`Command`](tokio::process::Command) confined
+//! to the sandbox workspace directory — identical semantics to
+//! [`LocalCommandRunner`](praxis_core::sandbox::LocalCommandRunner) but async.
+//!
+//! # Persistence
+//!
+//! Sandbox state lives in a per-sandbox subdirectory of `workspace_root`.
+//! [`snapshot`](BubblewrapProvider::snapshot) tars that directory;
+//! [`resume`](BubblewrapProvider::resume) untars it back.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tokio::fs;
+use tokio::process::Command;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use arcan_sandbox::capability::SandboxCapabilitySet;
+use arcan_sandbox::error::SandboxError;
+use arcan_sandbox::provider::SandboxProvider;
+use arcan_sandbox::types::{
+    ExecRequest, ExecResult, SandboxHandle, SandboxId, SandboxInfo, SandboxSpec, SandboxStatus,
+    SnapshotId,
+};
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+/// Sandbox provider backed by bubblewrap (`bwrap`) or a plain subprocess.
+///
+/// Construct with [`BubblewrapProvider::new`] or
+/// [`BubblewrapProvider::from_env`].
+#[derive(Debug, Clone)]
+pub struct BubblewrapProvider {
+    /// Root directory where per-sandbox workspace directories are created.
+    pub workspace_root: PathBuf,
+    /// `true` when the `bwrap` binary was found in `PATH` at construction.
+    pub use_bwrap: bool,
+}
+
+impl BubblewrapProvider {
+    /// Create a provider with an explicit workspace root.
+    ///
+    /// Auto-detects whether `bwrap` is available in `PATH`.
+    pub fn new(workspace_root: PathBuf) -> Self {
+        let use_bwrap = which_bwrap().is_some();
+        if use_bwrap {
+            info!("bwrap binary found — using bubblewrap isolation");
+        } else {
+            warn!("bwrap binary not found — falling back to plain subprocess");
+        }
+        Self { workspace_root, use_bwrap }
+    }
+
+    /// Create a provider reading `ARCAN_SANDBOX_ROOT` (default:
+    /// `/tmp/arcan-sandboxes`) and auto-detecting `bwrap`.
+    pub fn from_env() -> Self {
+        let root = std::env::var("ARCAN_SANDBOX_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("/tmp/arcan-sandboxes"));
+        Self::new(root)
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    /// Absolute path of the workspace directory for `id`.
+    fn workspace_dir(&self, id: &SandboxId) -> PathBuf {
+        self.workspace_root.join(&id.0)
+    }
+
+    /// Absolute path of the snapshot tarball for `id`.
+    fn snapshot_path(&self, id: &SandboxId) -> PathBuf {
+        self.workspace_root.join(format!("{}.tar.gz", id.0))
+    }
+
+    /// Derive the effective timeout for a request, falling back to the spec
+    /// default (60 s).
+    fn timeout_secs(req: &ExecRequest) -> u64 {
+        req.timeout_secs.unwrap_or(60)
+    }
+}
+
+#[async_trait]
+impl SandboxProvider for BubblewrapProvider {
+    fn name(&self) -> &'static str {
+        "bubblewrap"
+    }
+
+    /// Advertised capabilities.
+    ///
+    /// - [`FILESYSTEM_READ`](SandboxCapabilitySet::FILESYSTEM_READ)
+    /// - [`FILESYSTEM_WRITE`](SandboxCapabilitySet::FILESYSTEM_WRITE)
+    /// - [`PERSISTENCE`](SandboxCapabilitySet::PERSISTENCE)
+    ///
+    /// `NETWORK_OUTBOUND` is deliberately omitted — bubblewrap uses
+    /// `--unshare-net` by default.
+    fn capabilities(&self) -> SandboxCapabilitySet {
+        SandboxCapabilitySet::FILESYSTEM_READ
+            | SandboxCapabilitySet::FILESYSTEM_WRITE
+            | SandboxCapabilitySet::PERSISTENCE
+    }
+
+    /// Create a new sandbox workspace directory.
+    ///
+    /// Returns immediately with `status: Running`. The workspace directory is
+    /// created at `{workspace_root}/{id}/`.
+    async fn create(&self, spec: SandboxSpec) -> Result<SandboxHandle, SandboxError> {
+        let id = SandboxId(Uuid::new_v4().to_string());
+        let workspace = self.workspace_dir(&id);
+
+        fs::create_dir_all(&workspace)
+            .await
+            .map_err(|e| SandboxError::ProviderError {
+                provider: "bubblewrap",
+                message: format!("create workspace dir: {e}"),
+            })?;
+
+        debug!(sandbox_id = %id, workspace = %workspace.display(), "sandbox workspace created");
+
+        Ok(SandboxHandle {
+            id,
+            name: spec.name,
+            status: SandboxStatus::Running,
+            created_at: Utc::now(),
+            provider: self.name().to_owned(),
+            metadata: serde_json::json!({
+                "workspace": workspace.display().to_string(),
+                "use_bwrap": self.use_bwrap,
+            }),
+        })
+    }
+
+    /// Restore a sandbox from its tarball snapshot.
+    ///
+    /// If the workspace directory already exists this is a no-op — the handle
+    /// is returned with `status: Running`. If the workspace is missing but a
+    /// tarball exists it is extracted.
+    async fn resume(&self, id: &SandboxId) -> Result<SandboxHandle, SandboxError> {
+        let workspace = self.workspace_dir(id);
+        let tarball = self.snapshot_path(id);
+
+        if !workspace.exists() {
+            if tarball.exists() {
+                // Untar the snapshot into workspace_root.
+                let status = Command::new("tar")
+                    .args(["-xzf", tarball.to_str().unwrap_or_default()])
+                    .args(["-C", self.workspace_root.to_str().unwrap_or_default()])
+                    .status()
+                    .await
+                    .map_err(|e| SandboxError::ProviderError {
+                        provider: "bubblewrap",
+                        message: format!("tar extract failed: {e}"),
+                    })?;
+
+                if !status.success() {
+                    return Err(SandboxError::ProviderError {
+                        provider: "bubblewrap",
+                        message: format!(
+                            "tar exited with {status} while extracting {tarball:?}"
+                        ),
+                    });
+                }
+
+                info!(sandbox_id = %id, "sandbox restored from snapshot");
+            } else {
+                return Err(SandboxError::NotFound(id.clone()));
+            }
+        }
+
+        Ok(SandboxHandle {
+            id: id.clone(),
+            name: id.0.clone(),
+            status: SandboxStatus::Running,
+            created_at: Utc::now(),
+            provider: self.name().to_owned(),
+            metadata: serde_json::json!({
+                "workspace": workspace.display().to_string(),
+                "use_bwrap": self.use_bwrap,
+            }),
+        })
+    }
+
+    /// Execute a command inside the sandbox workspace.
+    ///
+    /// Uses `bwrap` when available, otherwise falls back to a plain Tokio
+    /// subprocess with the current directory set to the workspace.
+    async fn run(&self, id: &SandboxId, req: ExecRequest) -> Result<ExecResult, SandboxError> {
+        let workspace = self.workspace_dir(id);
+        if !workspace.exists() {
+            return Err(SandboxError::NotFound(id.clone()));
+        }
+
+        if req.command.is_empty() {
+            return Err(SandboxError::ProviderError {
+                provider: "bubblewrap",
+                message: "command vector is empty".into(),
+            });
+        }
+
+        let timeout = std::time::Duration::from_secs(Self::timeout_secs(&req));
+        let start = Instant::now();
+
+        let mut cmd = build_command(&workspace, &req, self.use_bwrap);
+
+        let result = tokio::time::timeout(timeout, cmd.output()).await;
+
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+
+        match result {
+            Ok(Ok(output)) => {
+                let exit_code = output.status.code().unwrap_or(-1);
+                debug!(sandbox_id = %id, exit_code, duration_ms = elapsed_ms, "exec completed");
+                Ok(ExecResult {
+                    stdout: output.stdout,
+                    stderr: output.stderr,
+                    exit_code,
+                    duration_ms: elapsed_ms,
+                })
+            }
+            Ok(Err(e)) => Err(SandboxError::ProviderError {
+                provider: "bubblewrap",
+                message: format!("spawn failed: {e}"),
+            }),
+            Err(_) => Err(SandboxError::ExecTimeout {
+                sandbox_id: id.clone(),
+                timeout_secs: Self::timeout_secs(&req),
+            }),
+        }
+    }
+
+    /// Tar the workspace directory to `{workspace_root}/{id}.tar.gz`.
+    ///
+    /// Returns the filename as the [`SnapshotId`].
+    async fn snapshot(&self, id: &SandboxId) -> Result<SnapshotId, SandboxError> {
+        let workspace = self.workspace_dir(id);
+        if !workspace.exists() {
+            return Err(SandboxError::NotFound(id.clone()));
+        }
+
+        let tarball = self.snapshot_path(id);
+        let tarball_name = tarball
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_owned();
+
+        // tar -czf {tarball} -C {workspace_root} {id}
+        let status = Command::new("tar")
+            .args([
+                "-czf",
+                tarball.to_str().unwrap_or_default(),
+                "-C",
+                self.workspace_root.to_str().unwrap_or_default(),
+                &id.0,
+            ])
+            .status()
+            .await
+            .map_err(|e| SandboxError::ProviderError {
+                provider: "bubblewrap",
+                message: format!("tar create failed: {e}"),
+            })?;
+
+        if !status.success() {
+            return Err(SandboxError::ProviderError {
+                provider: "bubblewrap",
+                message: format!("tar exited with {status}"),
+            });
+        }
+
+        info!(sandbox_id = %id, snapshot = %tarball_name, "snapshot created");
+        Ok(SnapshotId(tarball_name))
+    }
+
+    /// Remove the workspace directory and any associated tarball.
+    ///
+    /// Succeeds even if neither exists.
+    async fn destroy(&self, id: &SandboxId) -> Result<(), SandboxError> {
+        let workspace = self.workspace_dir(id);
+        let tarball = self.snapshot_path(id);
+
+        if workspace.exists() {
+            fs::remove_dir_all(&workspace).await.map_err(|e| SandboxError::ProviderError {
+                provider: "bubblewrap",
+                message: format!("remove workspace: {e}"),
+            })?;
+        }
+        if tarball.exists() {
+            fs::remove_file(&tarball).await.map_err(|e| SandboxError::ProviderError {
+                provider: "bubblewrap",
+                message: format!("remove tarball: {e}"),
+            })?;
+        }
+
+        info!(sandbox_id = %id, "sandbox destroyed");
+        Ok(())
+    }
+
+    /// Scan `workspace_root` for directories and return a [`SandboxInfo`] for
+    /// each one found.
+    async fn list(&self) -> Result<Vec<SandboxInfo>, SandboxError> {
+        if !self.workspace_root.exists() {
+            return Ok(vec![]);
+        }
+
+        let mut entries = fs::read_dir(&self.workspace_root)
+            .await
+            .map_err(|e| SandboxError::ProviderError {
+                provider: "bubblewrap",
+                message: format!("read workspace_root: {e}"),
+            })?;
+
+        let mut infos = Vec::new();
+        while let Some(entry) = entries.next_entry().await.map_err(|e| {
+            SandboxError::ProviderError {
+                provider: "bubblewrap",
+                message: format!("read dir entry: {e}"),
+            }
+        })? {
+            let ft = entry
+                .file_type()
+                .await
+                .map_err(|e| SandboxError::ProviderError {
+                    provider: "bubblewrap",
+                    message: format!("file type: {e}"),
+                })?;
+            if !ft.is_dir() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let created_at = entry
+                .metadata()
+                .await
+                .and_then(|m| m.created())
+                .map(|st| {
+                    let dur = st
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default();
+                    let secs = dur.as_secs() as i64;
+                    chrono::DateTime::from_timestamp(secs, 0).unwrap_or_else(Utc::now)
+                })
+                .unwrap_or_else(|_| Utc::now());
+
+            infos.push(SandboxInfo {
+                id: SandboxId(name.clone()),
+                name,
+                status: SandboxStatus::Running,
+                created_at,
+            });
+        }
+
+        Ok(infos)
+    }
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Return the path to `bwrap` if it can be found in `PATH`.
+fn which_bwrap() -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|path_var| {
+        std::env::split_paths(&path_var).find_map(|dir| {
+            let candidate = dir.join("bwrap");
+            if candidate.is_file() { Some(candidate) } else { None }
+        })
+    })
+}
+
+/// Build a [`tokio::process::Command`] for the given request.
+///
+/// When `use_bwrap` is `true` the command is wrapped with `bwrap` arguments
+/// that bind-mount the workspace and common system directories.
+fn build_command(workspace: &Path, req: &ExecRequest, use_bwrap: bool) -> Command {
+    if use_bwrap {
+        let mut cmd = Command::new("bwrap");
+        cmd.args([
+            "--bind",
+            workspace.to_str().unwrap_or("/workspace"),
+            "/workspace",
+            "--proc",
+            "/proc",
+            "--dev",
+            "/dev",
+            "--ro-bind",
+            "/usr",
+            "/usr",
+            "--ro-bind",
+            "/lib",
+            "/lib",
+        ]);
+
+        // /lib64 may not exist on all systems; skip gracefully
+        if Path::new("/lib64").exists() {
+            cmd.args(["--ro-bind", "/lib64", "/lib64"]);
+        }
+
+        cmd.args([
+            "--ro-bind",
+            "/bin",
+            "/bin",
+            "--unshare-net",
+            "--new-session",
+            "--",
+        ]);
+
+        cmd.args(&req.command);
+        apply_exec_env(&mut cmd, req);
+        cmd
+    } else {
+        let mut cmd = Command::new(&req.command[0]);
+        cmd.args(&req.command[1..]);
+        cmd.current_dir(workspace);
+        apply_exec_env(&mut cmd, req);
+        cmd
+    }
+}
+
+/// Apply environment variables and optional working directory from the request.
+fn apply_exec_env(cmd: &mut Command, req: &ExecRequest) {
+    for (k, v) in &req.env {
+        cmd.env(k, v);
+    }
+    if let Some(dir) = &req.working_dir {
+        cmd.current_dir(dir);
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider_at(root: &Path) -> BubblewrapProvider {
+        BubblewrapProvider { workspace_root: root.to_path_buf(), use_bwrap: false }
+    }
+
+    #[tokio::test]
+    async fn create_and_destroy_creates_and_removes_workspace_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let provider = provider_at(tmp.path());
+
+        let handle = provider.create(SandboxSpec::ephemeral("test")).await.unwrap();
+        let workspace = provider.workspace_dir(&handle.id);
+        assert!(workspace.exists(), "workspace dir should exist after create");
+
+        provider.destroy(&handle.id).await.unwrap();
+        assert!(!workspace.exists(), "workspace dir should be removed after destroy");
+    }
+
+    #[tokio::test]
+    async fn run_echo_command_succeeds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let provider = provider_at(tmp.path());
+
+        let handle = provider.create(SandboxSpec::ephemeral("echo-test")).await.unwrap();
+
+        let req = ExecRequest {
+            command: vec!["echo".into(), "hello".into()],
+            working_dir: None,
+            env: Default::default(),
+            timeout_secs: Some(10),
+            stdin: None,
+        };
+
+        let result = provider.run(&handle.id, req).await.unwrap();
+        assert_eq!(result.exit_code, 0, "echo should exit 0");
+        assert!(result.stdout_str().contains("hello"), "stdout should contain 'hello'");
+
+        provider.destroy(&handle.id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn snapshot_produces_tarball() {
+        let tmp = tempfile::tempdir().unwrap();
+        let provider = provider_at(tmp.path());
+
+        let handle = provider.create(SandboxSpec::ephemeral("snap-test")).await.unwrap();
+        let snapshot_id = provider.snapshot(&handle.id).await.unwrap();
+
+        let tarball = provider.snapshot_path(&handle.id);
+        assert!(tarball.exists(), "tarball should exist after snapshot");
+        assert!(snapshot_id.0.ends_with(".tar.gz"), "snapshot id should be a .tar.gz filename");
+
+        provider.destroy(&handle.id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn resume_restores_from_tarball() {
+        let tmp = tempfile::tempdir().unwrap();
+        let provider = provider_at(tmp.path());
+
+        // Create, write a file, snapshot, destroy workspace dir, then resume.
+        let handle = provider.create(SandboxSpec::ephemeral("resume-test")).await.unwrap();
+        let workspace = provider.workspace_dir(&handle.id);
+
+        // Write a marker file.
+        tokio::fs::write(workspace.join("marker.txt"), b"alive").await.unwrap();
+
+        provider.snapshot(&handle.id).await.unwrap();
+
+        // Remove workspace dir only (keep tarball).
+        tokio::fs::remove_dir_all(&workspace).await.unwrap();
+        assert!(!workspace.exists());
+
+        let resumed = provider.resume(&handle.id).await.unwrap();
+        assert_eq!(resumed.id, handle.id);
+        assert!(workspace.exists(), "workspace dir should exist after resume");
+
+        provider.destroy(&handle.id).await.unwrap();
+    }
+
+    #[test]
+    fn name_returns_bubblewrap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let provider = provider_at(tmp.path());
+        assert_eq!(provider.name(), "bubblewrap");
+    }
+
+    /// A non-zero exit code must be forwarded without an error.
+    #[tokio::test]
+    async fn run_exit_code_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let provider = provider_at(tmp.path());
+
+        let handle = provider.create(SandboxSpec::ephemeral("exit-code-test")).await.unwrap();
+
+        let req = ExecRequest {
+            command: vec!["/bin/sh".into(), "-c".into(), "exit 1".into()],
+            working_dir: None,
+            env: Default::default(),
+            timeout_secs: Some(10),
+            stdin: None,
+        };
+
+        let result = provider.run(&handle.id, req).await.unwrap();
+        assert_eq!(result.exit_code, 1, "exit code 1 must be forwarded");
+
+        provider.destroy(&handle.id).await.unwrap();
+    }
+
+    /// A command that exceeds its timeout must return `ExecTimeout`.
+    #[tokio::test]
+    async fn run_timeout_returns_exec_timeout_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let provider = provider_at(tmp.path());
+
+        let handle =
+            provider.create(SandboxSpec::ephemeral("timeout-test")).await.unwrap();
+
+        let req = ExecRequest {
+            command: vec!["sleep".into(), "30".into()],
+            working_dir: None,
+            env: Default::default(),
+            timeout_secs: Some(1),
+            stdin: None,
+        };
+
+        let err = provider.run(&handle.id, req).await.unwrap_err();
+        assert!(
+            matches!(err, SandboxError::ExecTimeout { .. }),
+            "expected ExecTimeout, got: {err:?}"
+        );
+
+        provider.destroy(&handle.id).await.unwrap();
+    }
+
+    /// `resume` on an ID with no workspace and no tarball must return `NotFound`.
+    #[tokio::test]
+    async fn resume_unknown_id_returns_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let provider = provider_at(tmp.path());
+
+        let unknown_id = SandboxId("does-not-exist".into());
+        let err = provider.resume(&unknown_id).await.unwrap_err();
+        assert!(
+            matches!(err, SandboxError::NotFound(_)),
+            "expected NotFound, got: {err:?}"
+        );
+    }
+
+    /// `list` must return a `SandboxInfo` for each created sandbox.
+    #[tokio::test]
+    async fn list_returns_all_created_sandboxes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let provider = provider_at(tmp.path());
+
+        let h1 = provider.create(SandboxSpec::ephemeral("list-test-1")).await.unwrap();
+        let h2 = provider.create(SandboxSpec::ephemeral("list-test-2")).await.unwrap();
+
+        let infos = provider.list().await.unwrap();
+        let ids: Vec<_> = infos.iter().map(|i| &i.id).collect();
+
+        assert!(ids.contains(&&h1.id), "list must include first sandbox");
+        assert!(ids.contains(&&h2.id), "list must include second sandbox");
+
+        provider.destroy(&h1.id).await.unwrap();
+        provider.destroy(&h2.id).await.unwrap();
+    }
+}

--- a/crates/arcan-provider-bubblewrap/src/lib.rs
+++ b/crates/arcan-provider-bubblewrap/src/lib.rs
@@ -60,7 +60,10 @@ impl BubblewrapProvider {
         } else {
             warn!("bwrap binary not found — falling back to plain subprocess");
         }
-        Self { workspace_root, use_bwrap }
+        Self {
+            workspace_root,
+            use_bwrap,
+        }
     }
 
     /// Create a provider reading `ARCAN_SANDBOX_ROOT` (default:
@@ -166,9 +169,7 @@ impl SandboxProvider for BubblewrapProvider {
                 if !status.success() {
                     return Err(SandboxError::ProviderError {
                         provider: "bubblewrap",
-                        message: format!(
-                            "tar exited with {status} while extracting {tarball:?}"
-                        ),
+                        message: format!("tar exited with {status} while extracting {tarball:?}"),
                     });
                 }
 
@@ -290,16 +291,20 @@ impl SandboxProvider for BubblewrapProvider {
         let tarball = self.snapshot_path(id);
 
         if workspace.exists() {
-            fs::remove_dir_all(&workspace).await.map_err(|e| SandboxError::ProviderError {
-                provider: "bubblewrap",
-                message: format!("remove workspace: {e}"),
-            })?;
+            fs::remove_dir_all(&workspace)
+                .await
+                .map_err(|e| SandboxError::ProviderError {
+                    provider: "bubblewrap",
+                    message: format!("remove workspace: {e}"),
+                })?;
         }
         if tarball.exists() {
-            fs::remove_file(&tarball).await.map_err(|e| SandboxError::ProviderError {
-                provider: "bubblewrap",
-                message: format!("remove tarball: {e}"),
-            })?;
+            fs::remove_file(&tarball)
+                .await
+                .map_err(|e| SandboxError::ProviderError {
+                    provider: "bubblewrap",
+                    message: format!("remove tarball: {e}"),
+                })?;
         }
 
         info!(sandbox_id = %id, "sandbox destroyed");
@@ -313,20 +318,24 @@ impl SandboxProvider for BubblewrapProvider {
             return Ok(vec![]);
         }
 
-        let mut entries = fs::read_dir(&self.workspace_root)
-            .await
-            .map_err(|e| SandboxError::ProviderError {
-                provider: "bubblewrap",
-                message: format!("read workspace_root: {e}"),
-            })?;
+        let mut entries =
+            fs::read_dir(&self.workspace_root)
+                .await
+                .map_err(|e| SandboxError::ProviderError {
+                    provider: "bubblewrap",
+                    message: format!("read workspace_root: {e}"),
+                })?;
 
         let mut infos = Vec::new();
-        while let Some(entry) = entries.next_entry().await.map_err(|e| {
-            SandboxError::ProviderError {
-                provider: "bubblewrap",
-                message: format!("read dir entry: {e}"),
-            }
-        })? {
+        while let Some(entry) =
+            entries
+                .next_entry()
+                .await
+                .map_err(|e| SandboxError::ProviderError {
+                    provider: "bubblewrap",
+                    message: format!("read dir entry: {e}"),
+                })?
+        {
             let ft = entry
                 .file_type()
                 .await
@@ -343,9 +352,7 @@ impl SandboxProvider for BubblewrapProvider {
                 .await
                 .and_then(|m| m.created())
                 .map(|st| {
-                    let dur = st
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default();
+                    let dur = st.duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
                     let secs = dur.as_secs() as i64;
                     chrono::DateTime::from_timestamp(secs, 0).unwrap_or_else(Utc::now)
                 })
@@ -370,7 +377,11 @@ fn which_bwrap() -> Option<PathBuf> {
     std::env::var_os("PATH").and_then(|path_var| {
         std::env::split_paths(&path_var).find_map(|dir| {
             let candidate = dir.join("bwrap");
-            if candidate.is_file() { Some(candidate) } else { None }
+            if candidate.is_file() {
+                Some(candidate)
+            } else {
+                None
+            }
         })
     })
 }
@@ -441,7 +452,10 @@ mod tests {
     use super::*;
 
     fn provider_at(root: &Path) -> BubblewrapProvider {
-        BubblewrapProvider { workspace_root: root.to_path_buf(), use_bwrap: false }
+        BubblewrapProvider {
+            workspace_root: root.to_path_buf(),
+            use_bwrap: false,
+        }
     }
 
     #[tokio::test]
@@ -449,12 +463,21 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let provider = provider_at(tmp.path());
 
-        let handle = provider.create(SandboxSpec::ephemeral("test")).await.unwrap();
+        let handle = provider
+            .create(SandboxSpec::ephemeral("test"))
+            .await
+            .unwrap();
         let workspace = provider.workspace_dir(&handle.id);
-        assert!(workspace.exists(), "workspace dir should exist after create");
+        assert!(
+            workspace.exists(),
+            "workspace dir should exist after create"
+        );
 
         provider.destroy(&handle.id).await.unwrap();
-        assert!(!workspace.exists(), "workspace dir should be removed after destroy");
+        assert!(
+            !workspace.exists(),
+            "workspace dir should be removed after destroy"
+        );
     }
 
     #[tokio::test]
@@ -462,7 +485,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let provider = provider_at(tmp.path());
 
-        let handle = provider.create(SandboxSpec::ephemeral("echo-test")).await.unwrap();
+        let handle = provider
+            .create(SandboxSpec::ephemeral("echo-test"))
+            .await
+            .unwrap();
 
         let req = ExecRequest {
             command: vec!["echo".into(), "hello".into()],
@@ -474,7 +500,10 @@ mod tests {
 
         let result = provider.run(&handle.id, req).await.unwrap();
         assert_eq!(result.exit_code, 0, "echo should exit 0");
-        assert!(result.stdout_str().contains("hello"), "stdout should contain 'hello'");
+        assert!(
+            result.stdout_str().contains("hello"),
+            "stdout should contain 'hello'"
+        );
 
         provider.destroy(&handle.id).await.unwrap();
     }
@@ -484,12 +513,18 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let provider = provider_at(tmp.path());
 
-        let handle = provider.create(SandboxSpec::ephemeral("snap-test")).await.unwrap();
+        let handle = provider
+            .create(SandboxSpec::ephemeral("snap-test"))
+            .await
+            .unwrap();
         let snapshot_id = provider.snapshot(&handle.id).await.unwrap();
 
         let tarball = provider.snapshot_path(&handle.id);
         assert!(tarball.exists(), "tarball should exist after snapshot");
-        assert!(snapshot_id.0.ends_with(".tar.gz"), "snapshot id should be a .tar.gz filename");
+        assert!(
+            snapshot_id.0.ends_with(".tar.gz"),
+            "snapshot id should be a .tar.gz filename"
+        );
 
         provider.destroy(&handle.id).await.unwrap();
     }
@@ -500,11 +535,16 @@ mod tests {
         let provider = provider_at(tmp.path());
 
         // Create, write a file, snapshot, destroy workspace dir, then resume.
-        let handle = provider.create(SandboxSpec::ephemeral("resume-test")).await.unwrap();
+        let handle = provider
+            .create(SandboxSpec::ephemeral("resume-test"))
+            .await
+            .unwrap();
         let workspace = provider.workspace_dir(&handle.id);
 
         // Write a marker file.
-        tokio::fs::write(workspace.join("marker.txt"), b"alive").await.unwrap();
+        tokio::fs::write(workspace.join("marker.txt"), b"alive")
+            .await
+            .unwrap();
 
         provider.snapshot(&handle.id).await.unwrap();
 
@@ -514,7 +554,10 @@ mod tests {
 
         let resumed = provider.resume(&handle.id).await.unwrap();
         assert_eq!(resumed.id, handle.id);
-        assert!(workspace.exists(), "workspace dir should exist after resume");
+        assert!(
+            workspace.exists(),
+            "workspace dir should exist after resume"
+        );
 
         provider.destroy(&handle.id).await.unwrap();
     }
@@ -532,7 +575,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let provider = provider_at(tmp.path());
 
-        let handle = provider.create(SandboxSpec::ephemeral("exit-code-test")).await.unwrap();
+        let handle = provider
+            .create(SandboxSpec::ephemeral("exit-code-test"))
+            .await
+            .unwrap();
 
         let req = ExecRequest {
             command: vec!["/bin/sh".into(), "-c".into(), "exit 1".into()],
@@ -554,8 +600,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let provider = provider_at(tmp.path());
 
-        let handle =
-            provider.create(SandboxSpec::ephemeral("timeout-test")).await.unwrap();
+        let handle = provider
+            .create(SandboxSpec::ephemeral("timeout-test"))
+            .await
+            .unwrap();
 
         let req = ExecRequest {
             command: vec!["sleep".into(), "30".into()],
@@ -594,8 +642,14 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let provider = provider_at(tmp.path());
 
-        let h1 = provider.create(SandboxSpec::ephemeral("list-test-1")).await.unwrap();
-        let h2 = provider.create(SandboxSpec::ephemeral("list-test-2")).await.unwrap();
+        let h1 = provider
+            .create(SandboxSpec::ephemeral("list-test-1"))
+            .await
+            .unwrap();
+        let h2 = provider
+            .create(SandboxSpec::ephemeral("list-test-2"))
+            .await
+            .unwrap();
 
         let infos = provider.list().await.unwrap();
         let ids: Vec<_> = infos.iter().map(|i| &i.id).collect();

--- a/crates/arcan-provider-local/Cargo.toml
+++ b/crates/arcan-provider-local/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "arcan-provider-local"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SandboxProvider implementation with Docker primary backend and nsjail fallback"
+
+[lints]
+workspace = true
+
+[dependencies]
+arcan-sandbox.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { version = "1", features = ["process", "fs", "rt", "macros", "rt-multi-thread", "time"] }
+uuid.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/arcan-provider-local/src/lib.rs
+++ b/crates/arcan-provider-local/src/lib.rs
@@ -93,7 +93,10 @@ impl LocalSandboxProvider {
     ) -> Result<Self, anyhow::Error> {
         if let Some(socket) = docker_socket {
             info!(socket = %socket.display(), "Docker socket found — using Docker backend");
-            return Ok(Self { backend: LocalBackend::Docker { socket }, workspace_root });
+            return Ok(Self {
+                backend: LocalBackend::Docker { socket },
+                workspace_root,
+            });
         }
 
         if let Some(bin) = nsjail_bin {
@@ -111,12 +114,18 @@ impl LocalSandboxProvider {
 
     /// Construct with a specific Docker socket path.
     pub fn with_docker(socket: PathBuf, workspace_root: PathBuf) -> Self {
-        Self { backend: LocalBackend::Docker { socket }, workspace_root }
+        Self {
+            backend: LocalBackend::Docker { socket },
+            workspace_root,
+        }
     }
 
     /// Construct with a specific nsjail binary path.
     pub fn with_nsjail(nsjail_bin: PathBuf, workspace_root: PathBuf) -> Self {
-        Self { backend: LocalBackend::Nsjail { nsjail_bin }, workspace_root }
+        Self {
+            backend: LocalBackend::Nsjail { nsjail_bin },
+            workspace_root,
+        }
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
@@ -138,7 +147,10 @@ impl LocalSandboxProvider {
 
     /// Map a general error message to [`SandboxError::ProviderError`].
     fn err(msg: impl Into<String>) -> SandboxError {
-        SandboxError::ProviderError { provider: "local", message: msg.into() }
+        SandboxError::ProviderError {
+            provider: "local",
+            message: msg.into(),
+        }
     }
 
     // ── Docker impl ──────────────────────────────────────────────────────────
@@ -147,9 +159,9 @@ impl LocalSandboxProvider {
         let container = Self::container_name(id);
         let workspace = self.workspace_dir(id);
 
-        fs::create_dir_all(&workspace).await.map_err(|e| {
-            Self::err(format!("create workspace dir: {e}"))
-        })?;
+        fs::create_dir_all(&workspace)
+            .await
+            .map_err(|e| Self::err(format!("create workspace dir: {e}")))?;
 
         let image = spec.image.as_deref().unwrap_or("ubuntu:22.04");
         let mem_limit = format!("{}m", spec.resources.memory_mb);
@@ -159,14 +171,21 @@ impl LocalSandboxProvider {
 
         // Build argv explicitly — no shell interpolation.
         let args: &[&str] = &[
-            "run", "-d",
-            "--name", &container,
-            "--label", &session_label,
-            "--memory", &mem_limit,
-            "--cpus", &cpus,
-            "-v", &volume,
+            "run",
+            "-d",
+            "--name",
+            &container,
+            "--label",
+            &session_label,
+            "--memory",
+            &mem_limit,
+            "--cpus",
+            &cpus,
+            "-v",
+            &volume,
             image,
-            "sleep", "infinity",
+            "sleep",
+            "infinity",
         ];
 
         let out = Command::new("docker")
@@ -221,7 +240,10 @@ impl LocalSandboxProvider {
                 duration_ms: elapsed_ms,
             }),
             Ok(Err(e)) => Err(Self::err(format!("docker exec spawn: {e}"))),
-            Err(_) => Err(SandboxError::ExecTimeout { sandbox_id: id.clone(), timeout_secs }),
+            Err(_) => Err(SandboxError::ExecTimeout {
+                sandbox_id: id.clone(),
+                timeout_secs,
+            }),
         }
     }
 
@@ -262,12 +284,17 @@ impl LocalSandboxProvider {
             let volume = format!("{}:/workspace", workspace.display());
             let session_label = format!("arcan.session={}", id.0);
             let run_args: &[&str] = &[
-                "run", "-d",
-                "--name", &container,
-                "--label", &session_label,
-                "-v", &volume,
+                "run",
+                "-d",
+                "--name",
+                &container,
+                "--label",
+                &session_label,
+                "-v",
+                &volume,
                 &snapshot_image,
-                "sleep", "infinity",
+                "sleep",
+                "infinity",
             ];
             let run_out = Command::new("docker")
                 .args(run_args)
@@ -295,7 +322,10 @@ impl LocalSandboxProvider {
         let workspace = self.workspace_dir(id);
 
         // Ignore errors — container may already be gone.
-        let _ = Command::new("docker").args(["rm", "-f", &container]).output().await;
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &container])
+            .output()
+            .await;
 
         if workspace.exists() {
             fs::remove_dir_all(&workspace)
@@ -309,9 +339,12 @@ impl LocalSandboxProvider {
     async fn docker_list(&self) -> Result<Vec<SandboxInfo>, SandboxError> {
         let out = Command::new("docker")
             .args([
-                "ps", "-a",
-                "--filter", "label=arcan.session",
-                "--format", "{{.ID}}\t{{.Names}}\t{{.Status}}\t{{.CreatedAt}}",
+                "ps",
+                "-a",
+                "--filter",
+                "label=arcan.session",
+                "--format",
+                "{{.ID}}\t{{.Names}}\t{{.Status}}\t{{.CreatedAt}}",
             ])
             .output()
             .await
@@ -405,7 +438,10 @@ impl LocalSandboxProvider {
                 duration_ms: elapsed_ms,
             }),
             Ok(Err(e)) => Err(Self::err(format!("nsjail spawn: {e}"))),
-            Err(_) => Err(SandboxError::ExecTimeout { sandbox_id: id.clone(), timeout_secs }),
+            Err(_) => Err(SandboxError::ExecTimeout {
+                sandbox_id: id.clone(),
+                timeout_secs,
+            }),
         }
     }
 
@@ -504,11 +540,15 @@ impl LocalSandboxProvider {
             .map_err(|e| Self::err(format!("read workspace_root: {e}")))?;
 
         let mut infos = Vec::new();
-        while let Some(entry) =
-            entries.next_entry().await.map_err(|e| Self::err(format!("dir entry: {e}")))?
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|e| Self::err(format!("dir entry: {e}")))?
         {
-            let ft =
-                entry.file_type().await.map_err(|e| Self::err(format!("file type: {e}")))?;
+            let ft = entry
+                .file_type()
+                .await
+                .map_err(|e| Self::err(format!("file type: {e}")))?;
             if !ft.is_dir() {
                 continue;
             }
@@ -520,7 +560,7 @@ impl LocalSandboxProvider {
                 .map(|st| {
                     let dur = st.duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
                     let secs = dur.as_secs() as i64;
-                    chrono::DateTime::from_timestamp(secs, 0).unwrap_or_else(|| Utc::now())
+                    chrono::DateTime::from_timestamp(secs, 0).unwrap_or_else(Utc::now)
                 })
                 .unwrap_or_else(|_| Utc::now());
 
@@ -603,9 +643,7 @@ impl SandboxProvider for LocalSandboxProvider {
     async fn run(&self, id: &SandboxId, req: ExecRequest) -> Result<ExecResult, SandboxError> {
         match &self.backend {
             LocalBackend::Docker { .. } => self.docker_exec(id, &req).await,
-            LocalBackend::Nsjail { nsjail_bin } => {
-                self.nsjail_exec(id, &req, nsjail_bin).await
-            }
+            LocalBackend::Nsjail { nsjail_bin } => self.nsjail_exec(id, &req, nsjail_bin).await,
         }
     }
 
@@ -644,7 +682,11 @@ fn find_docker_socket() -> Option<PathBuf> {
         if p.exists() { Some(p) } else { None }
     } else {
         let default = PathBuf::from("/var/run/docker.sock");
-        if default.exists() { Some(default) } else { None }
+        if default.exists() {
+            Some(default)
+        } else {
+            None
+        }
     }
 }
 
@@ -653,7 +695,11 @@ fn which_binary(name: &str) -> Option<PathBuf> {
     std::env::var_os("PATH").and_then(|path_var| {
         std::env::split_paths(&path_var).find_map(|dir| {
             let candidate = dir.join(name);
-            if candidate.is_file() { Some(candidate) } else { None }
+            if candidate.is_file() {
+                Some(candidate)
+            } else {
+                None
+            }
         })
     })
 }
@@ -666,18 +712,12 @@ mod tests {
 
     /// Build a nsjail-backed provider at a temp directory.
     fn nsjail_provider(root: &Path) -> LocalSandboxProvider {
-        LocalSandboxProvider::with_nsjail(
-            PathBuf::from("/usr/sbin/nsjail"),
-            root.to_path_buf(),
-        )
+        LocalSandboxProvider::with_nsjail(PathBuf::from("/usr/sbin/nsjail"), root.to_path_buf())
     }
 
     /// Build a Docker-backed provider at a temp directory.
     fn docker_provider(root: &Path) -> LocalSandboxProvider {
-        LocalSandboxProvider::with_docker(
-            PathBuf::from("/var/run/docker.sock"),
-            root.to_path_buf(),
-        )
+        LocalSandboxProvider::with_docker(PathBuf::from("/var/run/docker.sock"), root.to_path_buf())
     }
 
     #[test]
@@ -689,7 +729,10 @@ mod tests {
             None, // no docker socket
             None, // no nsjail binary
         );
-        assert!(result.is_err(), "should fail when neither Docker nor nsjail is available");
+        assert!(
+            result.is_err(),
+            "should fail when neither Docker nor nsjail is available"
+        );
     }
 
     #[test]

--- a/crates/arcan-provider-local/src/lib.rs
+++ b/crates/arcan-provider-local/src/lib.rs
@@ -1,0 +1,729 @@
+//! `arcan-provider-local` — [`SandboxProvider`] with Docker primary backend
+//! and nsjail fallback.
+//!
+//! # Backend selection
+//!
+//! [`LocalSandboxProvider::from_env`] probes the environment at construction:
+//!
+//! 1. If `/var/run/docker.sock` (or `$DOCKER_HOST`) exists → use Docker.
+//! 2. If `nsjail` is in `PATH` → use nsjail.
+//! 3. Otherwise → return an error.
+//!
+//! # Docker backend
+//!
+//! Each sandbox maps to a long-running Docker container named `arcan-{id}`.
+//! The container is started with `sleep infinity` and commands are executed
+//! via `docker exec`.
+//!
+//! # nsjail backend (fallback)
+//!
+//! When Docker is unavailable the provider falls back to `nsjail`, using a
+//! workspace directory approach similar to `arcan-provider-bubblewrap`.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tokio::fs;
+use tokio::process::Command;
+use tracing::{debug, info};
+use uuid::Uuid;
+
+use arcan_sandbox::capability::SandboxCapabilitySet;
+use arcan_sandbox::error::SandboxError;
+use arcan_sandbox::provider::SandboxProvider;
+use arcan_sandbox::types::{
+    ExecRequest, ExecResult, SandboxHandle, SandboxId, SandboxInfo, SandboxSpec, SandboxStatus,
+    SnapshotId,
+};
+
+// ── Backend ──────────────────────────────────────────────────────────────────
+
+/// Describes which local isolation mechanism is in use.
+#[derive(Debug, Clone)]
+pub enum LocalBackend {
+    /// Docker daemon is available at the given socket path.
+    Docker {
+        /// Path to the Docker daemon socket (e.g. `/var/run/docker.sock`).
+        socket: PathBuf,
+    },
+    /// `nsjail` binary is available at the given path.
+    Nsjail {
+        /// Absolute path to the `nsjail` executable.
+        nsjail_bin: PathBuf,
+    },
+}
+
+// ── Provider ─────────────────────────────────────────────────────────────────
+
+/// Local sandbox provider with Docker primary backend and nsjail fallback.
+///
+/// Construct with [`LocalSandboxProvider::from_env`],
+/// [`LocalSandboxProvider::with_docker`], or
+/// [`LocalSandboxProvider::with_nsjail`].
+#[derive(Debug, Clone)]
+pub struct LocalSandboxProvider {
+    /// Which backend is in use.
+    pub backend: LocalBackend,
+    /// Root directory where per-sandbox workspace directories are stored.
+    pub workspace_root: PathBuf,
+}
+
+impl LocalSandboxProvider {
+    /// Detect the best available local backend.
+    ///
+    /// 1. Checks `DOCKER_HOST` env var or the default socket path for Docker.
+    /// 2. Falls back to searching `PATH` for `nsjail`.
+    /// 3. Returns `Err` if neither is available.
+    pub fn from_env() -> Result<Self, anyhow::Error> {
+        let workspace_root = std::env::var("ARCAN_SANDBOX_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("/tmp/arcan-sandboxes"));
+        Self::detect(workspace_root, find_docker_socket(), which_binary("nsjail"))
+    }
+
+    /// Internal constructor used by [`from_env`](Self::from_env) and tests.
+    ///
+    /// Accepts explicit optional values so tests avoid unsafe env mutation.
+    fn detect(
+        workspace_root: PathBuf,
+        docker_socket: Option<PathBuf>,
+        nsjail_bin: Option<PathBuf>,
+    ) -> Result<Self, anyhow::Error> {
+        if let Some(socket) = docker_socket {
+            info!(socket = %socket.display(), "Docker socket found — using Docker backend");
+            return Ok(Self { backend: LocalBackend::Docker { socket }, workspace_root });
+        }
+
+        if let Some(bin) = nsjail_bin {
+            info!(nsjail_bin = %bin.display(), "nsjail found — using nsjail backend");
+            return Ok(Self {
+                backend: LocalBackend::Nsjail { nsjail_bin: bin },
+                workspace_root,
+            });
+        }
+
+        anyhow::bail!(
+            "no local sandbox backend available: Docker socket not found and nsjail not in PATH"
+        )
+    }
+
+    /// Construct with a specific Docker socket path.
+    pub fn with_docker(socket: PathBuf, workspace_root: PathBuf) -> Self {
+        Self { backend: LocalBackend::Docker { socket }, workspace_root }
+    }
+
+    /// Construct with a specific nsjail binary path.
+    pub fn with_nsjail(nsjail_bin: PathBuf, workspace_root: PathBuf) -> Self {
+        Self { backend: LocalBackend::Nsjail { nsjail_bin }, workspace_root }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// Workspace directory for `id`.
+    fn workspace_dir(&self, id: &SandboxId) -> PathBuf {
+        self.workspace_root.join(&id.0)
+    }
+
+    /// Snapshot tarball path for `id`.
+    fn snapshot_path(&self, id: &SandboxId) -> PathBuf {
+        self.workspace_root.join(format!("{}.tar.gz", id.0))
+    }
+
+    /// Docker container name for `id`.
+    fn container_name(id: &SandboxId) -> String {
+        format!("arcan-{}", id.0)
+    }
+
+    /// Map a general error message to [`SandboxError::ProviderError`].
+    fn err(msg: impl Into<String>) -> SandboxError {
+        SandboxError::ProviderError { provider: "local", message: msg.into() }
+    }
+
+    // ── Docker impl ──────────────────────────────────────────────────────────
+
+    async fn docker_create(&self, spec: &SandboxSpec, id: &SandboxId) -> Result<(), SandboxError> {
+        let container = Self::container_name(id);
+        let workspace = self.workspace_dir(id);
+
+        fs::create_dir_all(&workspace).await.map_err(|e| {
+            Self::err(format!("create workspace dir: {e}"))
+        })?;
+
+        let image = spec.image.as_deref().unwrap_or("ubuntu:22.04");
+        let mem_limit = format!("{}m", spec.resources.memory_mb);
+        let cpus = spec.resources.vcpus.to_string();
+        let volume = format!("{}:/workspace", workspace.display());
+        let session_label = format!("arcan.session={}", id.0);
+
+        // Build argv explicitly — no shell interpolation.
+        let args: &[&str] = &[
+            "run", "-d",
+            "--name", &container,
+            "--label", &session_label,
+            "--memory", &mem_limit,
+            "--cpus", &cpus,
+            "-v", &volume,
+            image,
+            "sleep", "infinity",
+        ];
+
+        let out = Command::new("docker")
+            .args(args)
+            .output()
+            .await
+            .map_err(|e| Self::err(format!("docker run: {e}")))?;
+
+        if !out.status.success() {
+            return Err(Self::err(format!(
+                "docker run failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            )));
+        }
+
+        debug!(container, "docker container started");
+        Ok(())
+    }
+
+    async fn docker_exec(
+        &self,
+        id: &SandboxId,
+        req: &ExecRequest,
+    ) -> Result<ExecResult, SandboxError> {
+        let container = Self::container_name(id);
+        let timeout_secs = req.timeout_secs.unwrap_or(60);
+        let timeout = std::time::Duration::from_secs(timeout_secs);
+        let start = Instant::now();
+
+        // Compose argv: docker exec [-e K=V ...] [-w dir] <container> <command...>
+        let mut argv: Vec<String> = vec!["exec".into()];
+        for (k, v) in &req.env {
+            argv.push("-e".into());
+            argv.push(format!("{k}={v}"));
+        }
+        if let Some(dir) = &req.working_dir {
+            argv.push("-w".into());
+            argv.push(dir.clone());
+        }
+        argv.push(container.clone());
+        argv.extend(req.command.iter().cloned());
+
+        let result =
+            tokio::time::timeout(timeout, Command::new("docker").args(&argv).output()).await;
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+
+        match result {
+            Ok(Ok(out)) => Ok(ExecResult {
+                stdout: out.stdout,
+                stderr: out.stderr,
+                exit_code: out.status.code().unwrap_or(-1),
+                duration_ms: elapsed_ms,
+            }),
+            Ok(Err(e)) => Err(Self::err(format!("docker exec spawn: {e}"))),
+            Err(_) => Err(SandboxError::ExecTimeout { sandbox_id: id.clone(), timeout_secs }),
+        }
+    }
+
+    async fn docker_snapshot(&self, id: &SandboxId) -> Result<SnapshotId, SandboxError> {
+        let container = Self::container_name(id);
+        let image_name = format!("arcan-snap-{}", id.0);
+
+        let out = Command::new("docker")
+            .args(["commit", &container, &image_name])
+            .output()
+            .await
+            .map_err(|e| Self::err(format!("docker commit: {e}")))?;
+
+        if !out.status.success() {
+            return Err(Self::err(format!(
+                "docker commit failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            )));
+        }
+
+        Ok(SnapshotId(image_name))
+    }
+
+    async fn docker_resume(&self, id: &SandboxId) -> Result<SandboxHandle, SandboxError> {
+        let container = Self::container_name(id);
+        let snapshot_image = format!("arcan-snap-{}", id.0);
+
+        // Try `docker start` first (container already exists).
+        let out = Command::new("docker")
+            .args(["start", &container])
+            .output()
+            .await
+            .map_err(|e| Self::err(format!("docker start: {e}")))?;
+
+        if !out.status.success() {
+            // Container might not exist — try running from snapshot image.
+            let workspace = self.workspace_dir(id);
+            let volume = format!("{}:/workspace", workspace.display());
+            let session_label = format!("arcan.session={}", id.0);
+            let run_args: &[&str] = &[
+                "run", "-d",
+                "--name", &container,
+                "--label", &session_label,
+                "-v", &volume,
+                &snapshot_image,
+                "sleep", "infinity",
+            ];
+            let run_out = Command::new("docker")
+                .args(run_args)
+                .output()
+                .await
+                .map_err(|e| Self::err(format!("docker run from snapshot: {e}")))?;
+
+            if !run_out.status.success() {
+                return Err(SandboxError::NotFound(id.clone()));
+            }
+        }
+
+        Ok(SandboxHandle {
+            id: id.clone(),
+            name: id.0.clone(),
+            status: SandboxStatus::Running,
+            created_at: Utc::now(),
+            provider: self.name().to_owned(),
+            metadata: serde_json::json!({ "container": container }),
+        })
+    }
+
+    async fn docker_destroy(&self, id: &SandboxId) -> Result<(), SandboxError> {
+        let container = Self::container_name(id);
+        let workspace = self.workspace_dir(id);
+
+        // Ignore errors — container may already be gone.
+        let _ = Command::new("docker").args(["rm", "-f", &container]).output().await;
+
+        if workspace.exists() {
+            fs::remove_dir_all(&workspace)
+                .await
+                .map_err(|e| Self::err(format!("remove workspace: {e}")))?;
+        }
+
+        Ok(())
+    }
+
+    async fn docker_list(&self) -> Result<Vec<SandboxInfo>, SandboxError> {
+        let out = Command::new("docker")
+            .args([
+                "ps", "-a",
+                "--filter", "label=arcan.session",
+                "--format", "{{.ID}}\t{{.Names}}\t{{.Status}}\t{{.CreatedAt}}",
+            ])
+            .output()
+            .await
+            .map_err(|e| Self::err(format!("docker ps: {e}")))?;
+
+        if !out.status.success() {
+            return Err(Self::err(format!(
+                "docker ps failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            )));
+        }
+
+        let text = String::from_utf8_lossy(&out.stdout);
+        let mut infos = Vec::new();
+
+        for line in text.lines() {
+            let parts: Vec<&str> = line.splitn(4, '\t').collect();
+            if parts.len() < 2 {
+                continue;
+            }
+            let name = parts[1].trim_start_matches("arcan-").to_owned();
+            let status_str = parts.get(2).copied().unwrap_or("").to_lowercase();
+            let status = if status_str.contains("up") {
+                SandboxStatus::Running
+            } else {
+                SandboxStatus::Stopped
+            };
+
+            infos.push(SandboxInfo {
+                id: SandboxId(name.clone()),
+                name,
+                status,
+                created_at: Utc::now(),
+            });
+        }
+
+        Ok(infos)
+    }
+
+    // ── nsjail impl ──────────────────────────────────────────────────────────
+
+    async fn nsjail_create(&self, id: &SandboxId) -> Result<(), SandboxError> {
+        let workspace = self.workspace_dir(id);
+        fs::create_dir_all(&workspace)
+            .await
+            .map_err(|e| Self::err(format!("create workspace: {e}")))?;
+        Ok(())
+    }
+
+    async fn nsjail_exec(
+        &self,
+        id: &SandboxId,
+        req: &ExecRequest,
+        bin: &Path,
+    ) -> Result<ExecResult, SandboxError> {
+        let workspace = self.workspace_dir(id);
+        if !workspace.exists() {
+            return Err(SandboxError::NotFound(id.clone()));
+        }
+
+        let timeout_secs = req.timeout_secs.unwrap_or(60);
+        let timeout = std::time::Duration::from_secs(timeout_secs);
+        let start = Instant::now();
+
+        let bindmount = format!("{workdir}:/workspace", workdir = workspace.display());
+        let mut argv: Vec<String> = vec![
+            "--mode".into(),
+            "once".into(),
+            "--chroot".into(),
+            "/".into(),
+            "--bindmount".into(),
+            bindmount,
+            "--".into(),
+        ];
+        argv.extend(req.command.iter().cloned());
+
+        let mut cmd = Command::new(bin);
+        cmd.args(&argv);
+        for (k, v) in &req.env {
+            cmd.env(k, v);
+        }
+
+        let result = tokio::time::timeout(timeout, cmd.output()).await;
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+
+        match result {
+            Ok(Ok(out)) => Ok(ExecResult {
+                stdout: out.stdout,
+                stderr: out.stderr,
+                exit_code: out.status.code().unwrap_or(-1),
+                duration_ms: elapsed_ms,
+            }),
+            Ok(Err(e)) => Err(Self::err(format!("nsjail spawn: {e}"))),
+            Err(_) => Err(SandboxError::ExecTimeout { sandbox_id: id.clone(), timeout_secs }),
+        }
+    }
+
+    async fn nsjail_snapshot(&self, id: &SandboxId) -> Result<SnapshotId, SandboxError> {
+        let workspace = self.workspace_dir(id);
+        if !workspace.exists() {
+            return Err(SandboxError::NotFound(id.clone()));
+        }
+
+        let tarball = self.snapshot_path(id);
+        let tarball_name = tarball
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_owned();
+
+        let status = Command::new("tar")
+            .args([
+                "-czf",
+                tarball.to_str().unwrap_or_default(),
+                "-C",
+                self.workspace_root.to_str().unwrap_or_default(),
+                &id.0,
+            ])
+            .status()
+            .await
+            .map_err(|e| Self::err(format!("tar create: {e}")))?;
+
+        if !status.success() {
+            return Err(Self::err(format!("tar exited with {status}")));
+        }
+
+        Ok(SnapshotId(tarball_name))
+    }
+
+    async fn nsjail_resume(&self, id: &SandboxId) -> Result<SandboxHandle, SandboxError> {
+        let workspace = self.workspace_dir(id);
+        let tarball = self.snapshot_path(id);
+
+        if !workspace.exists() {
+            if tarball.exists() {
+                let status = Command::new("tar")
+                    .args([
+                        "-xzf",
+                        tarball.to_str().unwrap_or_default(),
+                        "-C",
+                        self.workspace_root.to_str().unwrap_or_default(),
+                    ])
+                    .status()
+                    .await
+                    .map_err(|e| Self::err(format!("tar extract: {e}")))?;
+
+                if !status.success() {
+                    return Err(Self::err(format!("tar extract exited with {status}")));
+                }
+            } else {
+                return Err(SandboxError::NotFound(id.clone()));
+            }
+        }
+
+        Ok(SandboxHandle {
+            id: id.clone(),
+            name: id.0.clone(),
+            status: SandboxStatus::Running,
+            created_at: Utc::now(),
+            provider: self.name().to_owned(),
+            metadata: serde_json::json!({ "workspace": workspace.display().to_string() }),
+        })
+    }
+
+    async fn nsjail_destroy(&self, id: &SandboxId) -> Result<(), SandboxError> {
+        let workspace = self.workspace_dir(id);
+        let tarball = self.snapshot_path(id);
+
+        if workspace.exists() {
+            fs::remove_dir_all(&workspace)
+                .await
+                .map_err(|e| Self::err(format!("remove workspace: {e}")))?;
+        }
+        if tarball.exists() {
+            fs::remove_file(&tarball)
+                .await
+                .map_err(|e| Self::err(format!("remove tarball: {e}")))?;
+        }
+
+        Ok(())
+    }
+
+    async fn nsjail_list(&self) -> Result<Vec<SandboxInfo>, SandboxError> {
+        if !self.workspace_root.exists() {
+            return Ok(vec![]);
+        }
+
+        let mut entries = fs::read_dir(&self.workspace_root)
+            .await
+            .map_err(|e| Self::err(format!("read workspace_root: {e}")))?;
+
+        let mut infos = Vec::new();
+        while let Some(entry) =
+            entries.next_entry().await.map_err(|e| Self::err(format!("dir entry: {e}")))?
+        {
+            let ft =
+                entry.file_type().await.map_err(|e| Self::err(format!("file type: {e}")))?;
+            if !ft.is_dir() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let created_at = entry
+                .metadata()
+                .await
+                .and_then(|m| m.created())
+                .map(|st| {
+                    let dur = st.duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
+                    let secs = dur.as_secs() as i64;
+                    chrono::DateTime::from_timestamp(secs, 0).unwrap_or_else(|| Utc::now())
+                })
+                .unwrap_or_else(|_| Utc::now());
+
+            infos.push(SandboxInfo {
+                id: SandboxId(name.clone()),
+                name,
+                status: SandboxStatus::Running,
+                created_at,
+            });
+        }
+        Ok(infos)
+    }
+}
+
+// ── SandboxProvider impl ──────────────────────────────────────────────────────
+
+#[async_trait]
+impl SandboxProvider for LocalSandboxProvider {
+    fn name(&self) -> &'static str {
+        "local"
+    }
+
+    /// Advertised capabilities.
+    ///
+    /// - [`FILESYSTEM_READ`](SandboxCapabilitySet::FILESYSTEM_READ)
+    /// - [`FILESYSTEM_WRITE`](SandboxCapabilitySet::FILESYSTEM_WRITE)
+    /// - [`CUSTOM_IMAGE`](SandboxCapabilitySet::CUSTOM_IMAGE) (Docker only)
+    /// - [`PERSISTENCE`](SandboxCapabilitySet::PERSISTENCE)
+    fn capabilities(&self) -> SandboxCapabilitySet {
+        let base = SandboxCapabilitySet::FILESYSTEM_READ
+            | SandboxCapabilitySet::FILESYSTEM_WRITE
+            | SandboxCapabilitySet::PERSISTENCE;
+
+        match &self.backend {
+            LocalBackend::Docker { .. } => base | SandboxCapabilitySet::CUSTOM_IMAGE,
+            LocalBackend::Nsjail { .. } => base,
+        }
+    }
+
+    async fn create(&self, spec: SandboxSpec) -> Result<SandboxHandle, SandboxError> {
+        let id = SandboxId(Uuid::new_v4().to_string());
+
+        match &self.backend {
+            LocalBackend::Docker { .. } => {
+                self.docker_create(&spec, &id).await?;
+                let container = Self::container_name(&id);
+                Ok(SandboxHandle {
+                    id,
+                    name: spec.name,
+                    status: SandboxStatus::Running,
+                    created_at: Utc::now(),
+                    provider: self.name().to_owned(),
+                    metadata: serde_json::json!({ "container": container }),
+                })
+            }
+            LocalBackend::Nsjail { .. } => {
+                self.nsjail_create(&id).await?;
+                let workspace = self.workspace_dir(&id);
+                Ok(SandboxHandle {
+                    id,
+                    name: spec.name,
+                    status: SandboxStatus::Running,
+                    created_at: Utc::now(),
+                    provider: self.name().to_owned(),
+                    metadata: serde_json::json!({
+                        "workspace": workspace.display().to_string()
+                    }),
+                })
+            }
+        }
+    }
+
+    async fn resume(&self, id: &SandboxId) -> Result<SandboxHandle, SandboxError> {
+        match &self.backend {
+            LocalBackend::Docker { .. } => self.docker_resume(id).await,
+            LocalBackend::Nsjail { .. } => self.nsjail_resume(id).await,
+        }
+    }
+
+    async fn run(&self, id: &SandboxId, req: ExecRequest) -> Result<ExecResult, SandboxError> {
+        match &self.backend {
+            LocalBackend::Docker { .. } => self.docker_exec(id, &req).await,
+            LocalBackend::Nsjail { nsjail_bin } => {
+                self.nsjail_exec(id, &req, nsjail_bin).await
+            }
+        }
+    }
+
+    async fn snapshot(&self, id: &SandboxId) -> Result<SnapshotId, SandboxError> {
+        match &self.backend {
+            LocalBackend::Docker { .. } => self.docker_snapshot(id).await,
+            LocalBackend::Nsjail { .. } => self.nsjail_snapshot(id).await,
+        }
+    }
+
+    async fn destroy(&self, id: &SandboxId) -> Result<(), SandboxError> {
+        match &self.backend {
+            LocalBackend::Docker { .. } => self.docker_destroy(id).await,
+            LocalBackend::Nsjail { .. } => self.nsjail_destroy(id).await,
+        }
+    }
+
+    async fn list(&self) -> Result<Vec<SandboxInfo>, SandboxError> {
+        match &self.backend {
+            LocalBackend::Docker { .. } => self.docker_list().await,
+            LocalBackend::Nsjail { .. } => self.nsjail_list().await,
+        }
+    }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Find the Docker socket path.
+///
+/// Checks `DOCKER_HOST` env var first, then the default socket location.
+fn find_docker_socket() -> Option<PathBuf> {
+    if let Ok(host) = std::env::var("DOCKER_HOST") {
+        // DOCKER_HOST may be `unix:///path/to/sock`
+        let path = host.trim_start_matches("unix://");
+        let p = PathBuf::from(path);
+        if p.exists() { Some(p) } else { None }
+    } else {
+        let default = PathBuf::from("/var/run/docker.sock");
+        if default.exists() { Some(default) } else { None }
+    }
+}
+
+/// Search `PATH` for `binary_name` and return its path if found.
+fn which_binary(name: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|path_var| {
+        std::env::split_paths(&path_var).find_map(|dir| {
+            let candidate = dir.join(name);
+            if candidate.is_file() { Some(candidate) } else { None }
+        })
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a nsjail-backed provider at a temp directory.
+    fn nsjail_provider(root: &Path) -> LocalSandboxProvider {
+        LocalSandboxProvider::with_nsjail(
+            PathBuf::from("/usr/sbin/nsjail"),
+            root.to_path_buf(),
+        )
+    }
+
+    /// Build a Docker-backed provider at a temp directory.
+    fn docker_provider(root: &Path) -> LocalSandboxProvider {
+        LocalSandboxProvider::with_docker(
+            PathBuf::from("/var/run/docker.sock"),
+            root.to_path_buf(),
+        )
+    }
+
+    #[test]
+    fn from_env_returns_err_when_no_backend_available() {
+        // Pass None for both socket and nsjail to simulate no backend available.
+        // Uses detect() directly so we avoid unsafe env mutation.
+        let result = LocalSandboxProvider::detect(
+            PathBuf::from("/tmp/arcan-sandboxes"),
+            None, // no docker socket
+            None, // no nsjail binary
+        );
+        assert!(result.is_err(), "should fail when neither Docker nor nsjail is available");
+    }
+
+    #[test]
+    fn with_nsjail_name_is_local() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = nsjail_provider(tmp.path());
+        assert_eq!(p.name(), "local");
+    }
+
+    #[test]
+    fn with_docker_name_is_local() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = docker_provider(tmp.path());
+        assert_eq!(p.name(), "local");
+    }
+
+    #[test]
+    fn capabilities_include_filesystem() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nsjail = nsjail_provider(tmp.path());
+        let docker = docker_provider(tmp.path());
+
+        let nsjail_caps = nsjail.capabilities();
+        assert!(nsjail_caps.contains(SandboxCapabilitySet::FILESYSTEM_READ));
+        assert!(nsjail_caps.contains(SandboxCapabilitySet::FILESYSTEM_WRITE));
+        assert!(nsjail_caps.contains(SandboxCapabilitySet::PERSISTENCE));
+
+        let docker_caps = docker.capabilities();
+        assert!(docker_caps.contains(SandboxCapabilitySet::FILESYSTEM_READ));
+        assert!(docker_caps.contains(SandboxCapabilitySet::FILESYSTEM_WRITE));
+        assert!(docker_caps.contains(SandboxCapabilitySet::PERSISTENCE));
+        assert!(
+            docker_caps.contains(SandboxCapabilitySet::CUSTOM_IMAGE),
+            "Docker backend should advertise CUSTOM_IMAGE"
+        );
+    }
+}

--- a/crates/arcan-provider-vercel/Cargo.toml
+++ b/crates/arcan-provider-vercel/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "arcan-provider-vercel"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Vercel Sandbox API provider implementation for Arcan (Firecracker microVM isolation)"
+
+[features]
+default = []
+sandbox-vercel = []
+
+[dependencies]
+arcan-sandbox.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+reqwest = { workspace = true }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+mockito = "1"
+tokio = { version = "1", features = ["rt", "macros"] }
+
+[lints]
+workspace = true

--- a/crates/arcan-provider-vercel/src/lib.rs
+++ b/crates/arcan-provider-vercel/src/lib.rs
@@ -1,0 +1,646 @@
+//! `arcan-provider-vercel` — [`SandboxProvider`] implementation backed by the
+//! [Vercel Sandbox API](https://vercel.com/docs/sandbox).
+//!
+//! # Isolation
+//!
+//! Every sandbox runs inside a dedicated Firecracker microVM; no kernel sharing
+//! between tenants.
+//!
+//! # Limits (as of beta)
+//!
+//! | Plan  | Max session | Concurrent |
+//! |-------|-------------|-----------|
+//! | Hobby | 45 min      | 10        |
+//! | Pro   | 5 hr        | 2 000     |
+//!
+//! # Snapshot semantics
+//!
+//! Vercel conflates *pause* and *snapshot* into a single `stop` operation:
+//! calling [`VercelSandboxProvider::snapshot`] issues
+//! `POST /v1/sandboxes/{id}/stop`.  Billing halts and state is preserved.
+//! [`VercelSandboxProvider::resume`] issues
+//! `POST /v1/sandboxes/{id}/sessions` to restore from the implicit snapshot.
+//! The [`SnapshotId`] returned by `snapshot()` is the sandbox ID itself.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use arcan_sandbox::{
+    capability::SandboxCapabilitySet,
+    error::SandboxError,
+    provider::SandboxProvider,
+    types::{
+        ExecRequest, ExecResult, SandboxHandle, SandboxId, SandboxInfo, SandboxSpec, SandboxStatus,
+        SnapshotId,
+    },
+};
+
+// ── Private HTTP request / response types ────────────────────────────────────
+
+/// Request body for `POST /v1/sandboxes`.
+#[derive(Serialize)]
+struct CreateSandboxRequest {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resources: Option<VercelResources>,
+    #[serde(default)]
+    persistent: bool,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    env: HashMap<String, String>,
+}
+
+/// CPU / memory resource hints sent to the Vercel API.
+#[derive(Serialize)]
+struct VercelResources {
+    /// Number of virtual CPUs.
+    cpu: u32,
+    /// RAM in megabytes.
+    memory: u32,
+}
+
+/// Response from `POST /v1/sandboxes` and `GET /v1/sandboxes`.
+#[derive(Deserialize)]
+struct VercelSandbox {
+    id: String,
+    name: String,
+    /// `"starting" | "running" | "stopped" | "error"`
+    status: String,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+}
+
+/// Request body for `POST /v1/sandboxes/{id}/exec`.
+#[derive(Serialize)]
+struct ExecSandboxRequest {
+    command: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeout: Option<u64>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    env: HashMap<String, String>,
+}
+
+/// Response from `POST /v1/sandboxes/{id}/exec`.
+#[derive(Deserialize)]
+struct ExecSandboxResponse {
+    stdout: String,
+    stderr: String,
+    #[serde(rename = "exitCode")]
+    exit_code: i32,
+    #[serde(rename = "durationMs")]
+    duration_ms: u64,
+}
+
+/// Wrapper around the list endpoint response.
+#[derive(Deserialize)]
+struct ListSandboxesResponse {
+    sandboxes: Vec<VercelSandbox>,
+}
+
+// ── Provider struct ───────────────────────────────────────────────────────────
+
+/// [`SandboxProvider`] implementation backed by the Vercel Sandbox API.
+///
+/// Isolation: Firecracker microVM (dedicated kernel per sandbox).
+///
+/// Hobby limits: 45 min max session, 10 concurrent.
+/// Pro limits:   5 hr max session, 2,000 concurrent.
+pub struct VercelSandboxProvider {
+    client: reqwest::Client,
+    api_token: String,
+    team_id: Option<String>,
+    base_url: String,
+}
+
+impl VercelSandboxProvider {
+    /// Construct from explicit parameters.
+    ///
+    /// `api_token` is the Vercel bearer token; `team_id` is optional and
+    /// appended as `?teamId=…` to every request when present.
+    pub fn new(api_token: impl Into<String>, team_id: Option<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_token: api_token.into(),
+            team_id,
+            base_url: "https://api.vercel.com".into(),
+        }
+    }
+
+    /// Construct from environment variables.
+    ///
+    /// Reads `VERCEL_TOKEN` (preferred) or `VERCEL_SANDBOX_API_KEY` for the
+    /// bearer token.  Reads `VERCEL_TEAM_ID` for the optional team scope.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SandboxError::ProviderError`] if neither token variable is set.
+    pub fn from_env() -> Result<Self, SandboxError> {
+        Self::from_env_fn(|key| std::env::var(key))
+    }
+
+    /// Internal constructor that accepts a custom env-lookup function.
+    ///
+    /// This indirection allows unit tests to inject a controlled environment
+    /// without mutating the process-wide environment (which requires `unsafe`
+    /// in Rust edition 2024).
+    fn from_env_fn<F, E>(env: F) -> Result<Self, SandboxError>
+    where
+        F: Fn(&str) -> Result<String, E>,
+    {
+        let api_token = env("VERCEL_TOKEN")
+            .or_else(|_| env("VERCEL_SANDBOX_API_KEY"))
+            .map_err(|_| SandboxError::ProviderError {
+                provider: "vercel",
+                message: "VERCEL_TOKEN or VERCEL_SANDBOX_API_KEY must be set".into(),
+            })?;
+        let team_id = env("VERCEL_TEAM_ID").ok();
+        Ok(Self::new(api_token, team_id))
+    }
+
+    /// Override the base URL (useful for tests or staging environments).
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────────────
+
+    /// Append `?teamId=…` when a team ID is configured.
+    fn url(&self, path: &str) -> String {
+        match &self.team_id {
+            Some(tid) => format!("{}{}?teamId={}", self.base_url, path, tid),
+            None => format!("{}{}", self.base_url, path),
+        }
+    }
+
+    /// Execute an HTTP request, retrying on 429 and 503 with exponential backoff
+    /// (max 3 attempts: 100 ms / 200 ms / 400 ms).
+    async fn send_with_retry(
+        &self,
+        build: impl Fn() -> reqwest::RequestBuilder,
+    ) -> Result<reqwest::Response, SandboxError> {
+        let delays: [u64; 3] = [100, 200, 400];
+        let mut last_err: Option<SandboxError> = None;
+
+        for (attempt, &delay_ms) in delays.iter().enumerate() {
+            let resp = build()
+                .header("Authorization", format!("Bearer {}", self.api_token))
+                .send()
+                .await
+                .map_err(|e| SandboxError::ProviderError {
+                    provider: "vercel",
+                    message: format!("HTTP transport error: {e}"),
+                })?;
+
+            let status = resp.status();
+
+            if status.as_u16() == 429 || status.as_u16() == 503 {
+                warn!(
+                    attempt = attempt + 1,
+                    status = status.as_u16(),
+                    delay_ms,
+                    "Vercel API rate-limited / unavailable; retrying"
+                );
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                last_err = Some(SandboxError::ProviderError {
+                    provider: "vercel",
+                    message: format!("HTTP {status}: rate-limited or service unavailable"),
+                });
+                continue;
+            }
+
+            return Ok(resp);
+        }
+
+        Err(last_err.unwrap_or_else(|| SandboxError::ProviderError {
+            provider: "vercel",
+            message: "request failed after all retries".into(),
+        }))
+    }
+}
+
+// ── Status / error helpers ────────────────────────────────────────────────────
+
+/// Convert a Vercel status string to [`SandboxStatus`].
+fn map_status(s: &str) -> SandboxStatus {
+    match s {
+        "starting" => SandboxStatus::Starting,
+        "running" => SandboxStatus::Running,
+        "stopped" | "snapshotted" => SandboxStatus::Snapshotted,
+        "stopping" => SandboxStatus::Stopping,
+        "error" => SandboxStatus::Failed {
+            reason: "provider reported error".into(),
+        },
+        _ => SandboxStatus::Running, // unknown → assume running
+    }
+}
+
+/// Map an HTTP error status to a [`SandboxError`].
+fn map_status_error(
+    status: reqwest::StatusCode,
+    body: &str,
+    sandbox_id: Option<&SandboxId>,
+) -> SandboxError {
+    match status.as_u16() {
+        404 => SandboxError::NotFound(
+            sandbox_id
+                .cloned()
+                .unwrap_or_else(|| SandboxId("unknown".into())),
+        ),
+        402 | 403 => SandboxError::CapabilityDenied {
+            capability: "api_access",
+        },
+        408 | 504 => SandboxError::ExecTimeout {
+            sandbox_id: sandbox_id
+                .cloned()
+                .unwrap_or_else(|| SandboxId("unknown".into())),
+            timeout_secs: 0,
+        },
+        _ => SandboxError::ProviderError {
+            provider: "vercel",
+            message: format!("HTTP {}: {}", status, body),
+        },
+    }
+}
+
+/// Parse a Vercel sandbox into a [`SandboxHandle`].
+fn vercel_sandbox_to_handle(s: VercelSandbox) -> Result<SandboxHandle, SandboxError> {
+    let created_at: DateTime<Utc> =
+        s.created_at
+            .parse()
+            .map_err(|e| SandboxError::ProviderError {
+                provider: "vercel",
+                message: format!("invalid createdAt timestamp '{}': {e}", s.created_at),
+            })?;
+    Ok(SandboxHandle {
+        id: SandboxId(s.id),
+        name: s.name,
+        status: map_status(&s.status),
+        created_at,
+        provider: "vercel".into(),
+        metadata: serde_json::Value::Null,
+    })
+}
+
+/// Parse a Vercel sandbox into a [`SandboxInfo`].
+fn vercel_sandbox_to_info(s: VercelSandbox) -> Result<SandboxInfo, SandboxError> {
+    let created_at: DateTime<Utc> =
+        s.created_at
+            .parse()
+            .map_err(|e| SandboxError::ProviderError {
+                provider: "vercel",
+                message: format!("invalid createdAt timestamp '{}': {e}", s.created_at),
+            })?;
+    Ok(SandboxInfo {
+        id: SandboxId(s.id),
+        name: s.name,
+        status: map_status(&s.status),
+        created_at,
+    })
+}
+
+// ── SandboxProvider impl ──────────────────────────────────────────────────────
+
+#[async_trait]
+impl SandboxProvider for VercelSandboxProvider {
+    fn name(&self) -> &'static str {
+        "vercel"
+    }
+
+    /// Returns the capability set supported by the Vercel sandbox backend.
+    ///
+    /// Note: `CUSTOM_IMAGE` is not included; the Vercel beta does not expose
+    /// image selection to callers.
+    fn capabilities(&self) -> SandboxCapabilitySet {
+        SandboxCapabilitySet::FILESYSTEM_READ
+            | SandboxCapabilitySet::FILESYSTEM_WRITE
+            | SandboxCapabilitySet::NETWORK_OUTBOUND
+            | SandboxCapabilitySet::PERSISTENCE
+    }
+
+    /// Provision a new sandbox via `POST /v1/sandboxes`.
+    async fn create(&self, spec: SandboxSpec) -> Result<SandboxHandle, SandboxError> {
+        let url = self.url("/v1/sandboxes");
+        let persistent = !matches!(
+            spec.persistence,
+            arcan_sandbox::types::PersistencePolicy::Ephemeral
+        );
+        let body = CreateSandboxRequest {
+            name: spec.name.clone(),
+            resources: Some(VercelResources {
+                cpu: spec.resources.vcpus,
+                memory: spec.resources.memory_mb,
+            }),
+            persistent,
+            env: spec.env,
+        };
+
+        debug!(name = %spec.name, "creating Vercel sandbox");
+
+        let resp = self
+            .send_with_retry(|| self.client.post(&url).json(&body))
+            .await?;
+
+        let status = resp.status();
+        let body_text = resp.text().await.map_err(|e| SandboxError::ProviderError {
+            provider: "vercel",
+            message: format!("failed to read response body: {e}"),
+        })?;
+
+        if !status.is_success() {
+            return Err(map_status_error(status, &body_text, None));
+        }
+
+        let sandbox: VercelSandbox =
+            serde_json::from_str(&body_text).map_err(SandboxError::Serialization)?;
+        vercel_sandbox_to_handle(sandbox)
+    }
+
+    /// Resume a snapshotted sandbox via `POST /v1/sandboxes/{id}/sessions`.
+    async fn resume(&self, id: &SandboxId) -> Result<SandboxHandle, SandboxError> {
+        let url = self.url(&format!("/v1/sandboxes/{}/sessions", id.0));
+
+        debug!(sandbox_id = %id, "resuming Vercel sandbox");
+
+        let resp = self.send_with_retry(|| self.client.post(&url)).await?;
+        let status = resp.status();
+        let body_text = resp.text().await.map_err(|e| SandboxError::ProviderError {
+            provider: "vercel",
+            message: format!("failed to read response body: {e}"),
+        })?;
+
+        if !status.is_success() {
+            return Err(map_status_error(status, &body_text, Some(id)));
+        }
+
+        let sandbox: VercelSandbox =
+            serde_json::from_str(&body_text).map_err(SandboxError::Serialization)?;
+        vercel_sandbox_to_handle(sandbox)
+    }
+
+    /// Execute a command inside a running sandbox via `POST /v1/sandboxes/{id}/exec`.
+    async fn run(&self, id: &SandboxId, req: ExecRequest) -> Result<ExecResult, SandboxError> {
+        let url = self.url(&format!("/v1/sandboxes/{}/exec", id.0));
+        let body = ExecSandboxRequest {
+            command: req.command,
+            cwd: req.working_dir,
+            timeout: req.timeout_secs,
+            env: req.env,
+        };
+
+        debug!(sandbox_id = %id, "executing command in Vercel sandbox");
+
+        let resp = self
+            .send_with_retry(|| self.client.post(&url).json(&body))
+            .await?;
+        let status = resp.status();
+        let body_text = resp.text().await.map_err(|e| SandboxError::ProviderError {
+            provider: "vercel",
+            message: format!("failed to read response body: {e}"),
+        })?;
+
+        if !status.is_success() {
+            return Err(map_status_error(status, &body_text, Some(id)));
+        }
+
+        let exec_resp: ExecSandboxResponse =
+            serde_json::from_str(&body_text).map_err(SandboxError::Serialization)?;
+
+        Ok(ExecResult {
+            stdout: exec_resp.stdout.into_bytes(),
+            stderr: exec_resp.stderr.into_bytes(),
+            exit_code: exec_resp.exit_code,
+            duration_ms: exec_resp.duration_ms,
+        })
+    }
+
+    /// Snapshot the sandbox by stopping it via `POST /v1/sandboxes/{id}/stop`.
+    ///
+    /// Vercel auto-snapshots on stop; billing halts and state is preserved.
+    /// The returned [`SnapshotId`] is the sandbox ID itself (Vercel keeps a
+    /// single implicit snapshot per sandbox).
+    async fn snapshot(&self, id: &SandboxId) -> Result<SnapshotId, SandboxError> {
+        let url = self.url(&format!("/v1/sandboxes/{}/stop", id.0));
+
+        debug!(sandbox_id = %id, "snapshotting Vercel sandbox (stop)");
+
+        let resp = self.send_with_retry(|| self.client.post(&url)).await?;
+        let status = resp.status();
+
+        if !status.is_success() {
+            let body_text = resp.text().await.map_err(|e| SandboxError::ProviderError {
+                provider: "vercel",
+                message: format!("failed to read response body: {e}"),
+            })?;
+            return Err(map_status_error(status, &body_text, Some(id)));
+        }
+
+        // Vercel uses the sandbox ID as the implicit snapshot handle.
+        Ok(SnapshotId(id.0.clone()))
+    }
+
+    /// Permanently destroy a sandbox via `DELETE /v1/sandboxes/{id}`.
+    ///
+    /// Succeeds even if the sandbox is already stopped or not found.
+    async fn destroy(&self, id: &SandboxId) -> Result<(), SandboxError> {
+        let url = self.url(&format!("/v1/sandboxes/{}", id.0));
+
+        debug!(sandbox_id = %id, "destroying Vercel sandbox");
+
+        let resp = self.send_with_retry(|| self.client.delete(&url)).await?;
+        let status = resp.status();
+
+        // 404 is acceptable — already gone.
+        if status.as_u16() == 404 || status.is_success() {
+            return Ok(());
+        }
+
+        let body_text = resp.text().await.map_err(|e| SandboxError::ProviderError {
+            provider: "vercel",
+            message: format!("failed to read response body: {e}"),
+        })?;
+        Err(map_status_error(status, &body_text, Some(id)))
+    }
+
+    /// List all sandboxes visible to this provider via `GET /v1/sandboxes`.
+    async fn list(&self) -> Result<Vec<SandboxInfo>, SandboxError> {
+        let url = self.url("/v1/sandboxes");
+
+        debug!("listing Vercel sandboxes");
+
+        let resp = self.send_with_retry(|| self.client.get(&url)).await?;
+        let status = resp.status();
+        let body_text = resp.text().await.map_err(|e| SandboxError::ProviderError {
+            provider: "vercel",
+            message: format!("failed to read response body: {e}"),
+        })?;
+
+        if !status.is_success() {
+            return Err(map_status_error(status, &body_text, None));
+        }
+
+        let list_resp: ListSandboxesResponse =
+            serde_json::from_str(&body_text).map_err(SandboxError::Serialization)?;
+
+        list_resp
+            .sandboxes
+            .into_iter()
+            .map(vercel_sandbox_to_info)
+            .collect()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(unsafe_code)] // env mutation in tests requires unsafe (Rust 2024)
+mod tests {
+    use super::*;
+
+    /// Helper: build a provider that talks to the mock server.
+    fn provider_for(server: &mockito::Server) -> VercelSandboxProvider {
+        VercelSandboxProvider::new("test-token", None).with_base_url(server.url())
+    }
+
+    /// Canonical ISO-8601 timestamp used across fixtures.
+    const CREATED_AT: &str = "2026-01-01T00:00:00Z";
+
+    /// JSON fixture for a single VercelSandbox in "running" state.
+    fn running_sandbox_json(id: &str, name: &str) -> String {
+        format!(r#"{{"id":"{id}","name":"{name}","status":"running","createdAt":"{CREATED_AT}"}}"#)
+    }
+
+    // ── Static property tests (no network) ───────────────────────────────────
+
+    #[test]
+    fn name_is_vercel() {
+        let p = VercelSandboxProvider::new("tok", None);
+        assert_eq!(p.name(), "vercel");
+    }
+
+    #[test]
+    fn capabilities_include_network_outbound() {
+        let p = VercelSandboxProvider::new("tok", None);
+        assert!(
+            p.capabilities()
+                .contains(SandboxCapabilitySet::NETWORK_OUTBOUND)
+        );
+    }
+
+    #[test]
+    fn from_env_returns_err_without_token() {
+        // Inject a controlled env-lookup that never returns a value, avoiding
+        // any mutation of the process environment (which requires `unsafe`
+        // in Rust edition 2024 and is not permitted by workspace lints).
+        let result =
+            VercelSandboxProvider::from_env_fn(|_key: &str| -> Result<String, &'static str> {
+                Err("not set")
+            });
+        assert!(result.is_err(), "expected Err when no token env var is set");
+    }
+
+    // ── HTTP-level tests (mockito) ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn create_maps_spec_to_request() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/v1/sandboxes")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(running_sandbox_json("sbx-abc", "test-sandbox"))
+            .create_async()
+            .await;
+
+        let provider = provider_for(&server);
+        let spec = SandboxSpec::ephemeral("test-sandbox");
+        let handle = provider.create(spec).await.expect("create should succeed");
+
+        assert_eq!(handle.id.0, "sbx-abc");
+        assert_eq!(handle.name, "test-sandbox");
+        assert_eq!(handle.status, SandboxStatus::Running);
+        assert_eq!(handle.provider, "vercel");
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn run_maps_exec_request() {
+        let sandbox_id = "sbx-xyz";
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", format!("/v1/sandboxes/{sandbox_id}/exec").as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"stdout":"hello\n","stderr":"","exitCode":0,"durationMs":42}"#)
+            .create_async()
+            .await;
+
+        let provider = provider_for(&server);
+        let id = SandboxId(sandbox_id.into());
+        let req = ExecRequest::shell("echo hello");
+        let result = provider.run(&id, req).await.expect("run should succeed");
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.duration_ms, 42);
+        // stdout is the raw JSON string value (with literal \n escape)
+        assert!(String::from_utf8_lossy(&result.stdout).contains("hello"));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn error_404_maps_to_not_found() {
+        let sandbox_id = "sbx-missing";
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v1/sandboxes")
+            .with_status(404)
+            .with_body(r#"{"error":"not found"}"#)
+            .create_async()
+            .await;
+
+        let provider = provider_for(&server);
+        let err = provider.list().await.expect_err("should return error");
+        assert!(
+            matches!(err, SandboxError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
+        // suppress unused variable warning
+        let _ = sandbox_id;
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn error_429_retries() {
+        let mut server = mockito::Server::new_async().await;
+
+        // First call → 429, second call → 200
+        let mock_429 = server
+            .mock("GET", "/v1/sandboxes")
+            .with_status(429)
+            .with_body("")
+            .create_async()
+            .await;
+
+        let mock_200 = server
+            .mock("GET", "/v1/sandboxes")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"sandboxes":[]}"#)
+            .create_async()
+            .await;
+
+        let provider = provider_for(&server);
+        let result = provider.list().await;
+        assert!(result.is_ok(), "should succeed after retry; got {result:?}");
+        assert_eq!(result.unwrap().len(), 0);
+
+        mock_429.assert_async().await;
+        mock_200.assert_async().await;
+    }
+}

--- a/crates/arcan-sandbox/Cargo.toml
+++ b/crates/arcan-sandbox/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "arcan-sandbox"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Provider-agnostic SandboxProvider trait and core protocol types for Arcan"
+
+[dependencies]
+aios-protocol.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+bitflags.workspace = true
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
+
+[lints]
+workspace = true

--- a/crates/arcan-sandbox/src/capability.rs
+++ b/crates/arcan-sandbox/src/capability.rs
@@ -1,0 +1,155 @@
+//! Capability bitflags for sandboxed execution.
+//!
+//! `SandboxCapabilitySet` encodes what a sandbox is allowed to do as a compact
+//! bitmask. The companion `from_policy` constructor bridges from the
+//! string-pattern `PolicySet` used by the Agent OS policy engine.
+
+use aios_protocol::PolicySet;
+use bitflags::bitflags;
+use serde::{Deserialize, Serialize};
+
+bitflags! {
+    /// Compact bitmask of capabilities granted to a sandbox.
+    ///
+    /// Each bit maps to one permission axis. Providers advertise the set they
+    /// support via `SandboxProvider::capabilities()`; the spec passed to
+    /// `SandboxProvider::create()` carries the subset actually granted.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct SandboxCapabilitySet: u32 {
+        /// Sandbox may read files from the filesystem.
+        const FILESYSTEM_READ    = 0b0000_0001;
+        /// Sandbox may write files to the filesystem.
+        const FILESYSTEM_WRITE   = 0b0000_0010;
+        /// Sandbox may initiate outbound network connections.
+        const NETWORK_OUTBOUND   = 0b0000_0100;
+        /// Sandbox may accept inbound network connections.
+        const NETWORK_INBOUND    = 0b0000_1000;
+        /// Sandbox state may be snapshotted and resumed.
+        const PERSISTENCE        = 0b0001_0000;
+        /// Sandbox may use a custom container/VM image.
+        const CUSTOM_IMAGE       = 0b0010_0000;
+        /// Sandbox may access GPU hardware.
+        const GPU                = 0b0100_0000;
+    }
+}
+
+impl Default for SandboxCapabilitySet {
+    fn default() -> Self {
+        Self::FILESYSTEM_READ
+    }
+}
+
+impl SandboxCapabilitySet {
+    /// Derive a capability set from a `PolicySet` by inspecting its
+    /// `allow_capabilities` patterns.
+    ///
+    /// The mapping is intentionally conservative: a capability is enabled only
+    /// when an explicit `allow_capabilities` pattern covers it. Patterns are
+    /// matched by prefix:
+    ///
+    /// | Pattern prefix   | Enabled bit         |
+    /// |------------------|---------------------|
+    /// | `fs:read:`       | `FILESYSTEM_READ`   |
+    /// | `fs:write:`      | `FILESYSTEM_WRITE`  |
+    /// | `net:egress:`    | `NETWORK_OUTBOUND`  |
+    /// | `net:ingress:`   | `NETWORK_INBOUND`   |
+    /// | `sandbox:persist`| `PERSISTENCE`       |
+    /// | `sandbox:image`  | `CUSTOM_IMAGE`      |
+    /// | `sandbox:gpu`    | `GPU`               |
+    pub fn from_policy(policy: &PolicySet) -> Self {
+        let mut caps = Self::empty();
+        for cap in &policy.allow_capabilities {
+            let s = cap.as_str();
+            if s.starts_with("fs:read:") {
+                caps |= Self::FILESYSTEM_READ;
+            }
+            if s.starts_with("fs:write:") {
+                caps |= Self::FILESYSTEM_WRITE;
+            }
+            if s.starts_with("net:egress:") {
+                caps |= Self::NETWORK_OUTBOUND;
+            }
+            if s.starts_with("net:ingress:") {
+                caps |= Self::NETWORK_INBOUND;
+            }
+            if s.starts_with("sandbox:persist") {
+                caps |= Self::PERSISTENCE;
+            }
+            if s.starts_with("sandbox:image") {
+                caps |= Self::CUSTOM_IMAGE;
+            }
+            if s.starts_with("sandbox:gpu") {
+                caps |= Self::GPU;
+            }
+        }
+        caps
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aios_protocol::{Capability, PolicySet};
+
+    use super::*;
+
+    fn make_policy(caps: &[&str]) -> PolicySet {
+        PolicySet {
+            allow_capabilities: caps.iter().map(|s| Capability::new(*s)).collect(),
+            gate_capabilities: vec![],
+            max_tool_runtime_secs: 30,
+            max_events_per_turn: 10,
+        }
+    }
+
+    #[test]
+    fn empty_policy_yields_empty_caps() {
+        let caps = SandboxCapabilitySet::from_policy(&make_policy(&[]));
+        assert!(caps.is_empty());
+    }
+
+    #[test]
+    fn fs_read_pattern_maps_correctly() {
+        let caps = SandboxCapabilitySet::from_policy(&make_policy(&["fs:read:/session/**"]));
+        assert!(caps.contains(SandboxCapabilitySet::FILESYSTEM_READ));
+        assert!(!caps.contains(SandboxCapabilitySet::FILESYSTEM_WRITE));
+    }
+
+    #[test]
+    fn net_egress_maps_to_outbound() {
+        let caps =
+            SandboxCapabilitySet::from_policy(&make_policy(&["net:egress:api.openai.com"]));
+        assert!(caps.contains(SandboxCapabilitySet::NETWORK_OUTBOUND));
+        assert!(!caps.contains(SandboxCapabilitySet::NETWORK_INBOUND));
+    }
+
+    #[test]
+    fn multiple_capabilities_combine() {
+        let caps = SandboxCapabilitySet::from_policy(&make_policy(&[
+            "fs:read:/tmp/**",
+            "fs:write:/tmp/**",
+            "net:egress:*",
+            "sandbox:persist",
+        ]));
+        assert!(caps.contains(
+            SandboxCapabilitySet::FILESYSTEM_READ
+                | SandboxCapabilitySet::FILESYSTEM_WRITE
+                | SandboxCapabilitySet::NETWORK_OUTBOUND
+                | SandboxCapabilitySet::PERSISTENCE
+        ));
+        assert!(!caps.contains(SandboxCapabilitySet::GPU));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let caps = SandboxCapabilitySet::FILESYSTEM_READ | SandboxCapabilitySet::NETWORK_OUTBOUND;
+        let json = serde_json::to_string(&caps).unwrap();
+        let back: SandboxCapabilitySet = serde_json::from_str(&json).unwrap();
+        assert_eq!(caps, back);
+    }
+
+    #[test]
+    fn default_is_filesystem_read() {
+        assert_eq!(SandboxCapabilitySet::default(), SandboxCapabilitySet::FILESYSTEM_READ);
+    }
+}

--- a/crates/arcan-sandbox/src/capability.rs
+++ b/crates/arcan-sandbox/src/capability.rs
@@ -117,8 +117,7 @@ mod tests {
 
     #[test]
     fn net_egress_maps_to_outbound() {
-        let caps =
-            SandboxCapabilitySet::from_policy(&make_policy(&["net:egress:api.openai.com"]));
+        let caps = SandboxCapabilitySet::from_policy(&make_policy(&["net:egress:api.openai.com"]));
         assert!(caps.contains(SandboxCapabilitySet::NETWORK_OUTBOUND));
         assert!(!caps.contains(SandboxCapabilitySet::NETWORK_INBOUND));
     }
@@ -150,6 +149,9 @@ mod tests {
 
     #[test]
     fn default_is_filesystem_read() {
-        assert_eq!(SandboxCapabilitySet::default(), SandboxCapabilitySet::FILESYSTEM_READ);
+        assert_eq!(
+            SandboxCapabilitySet::default(),
+            SandboxCapabilitySet::FILESYSTEM_READ
+        );
     }
 }

--- a/crates/arcan-sandbox/src/error.rs
+++ b/crates/arcan-sandbox/src/error.rs
@@ -1,0 +1,87 @@
+//! Error types for sandbox operations.
+
+use thiserror::Error;
+
+use crate::types::SandboxId;
+
+/// All errors that can occur during sandbox lifecycle operations.
+#[derive(Debug, Error)]
+pub enum SandboxError {
+    /// No sandbox with the given ID exists or is visible to this provider.
+    #[error("sandbox not found: {0}")]
+    NotFound(SandboxId),
+
+    /// The requested operation is not supported by this provider.
+    ///
+    /// `reason` names the unsupported feature (e.g., `"persistence"`,
+    /// `"custom_image"`).
+    #[error("operation not supported by provider '{provider}': {reason}")]
+    NotSupported {
+        /// Provider that rejected the call.
+        provider: &'static str,
+        /// Human-readable name of the unsupported feature.
+        reason: &'static str,
+    },
+
+    /// A provider-specific error that doesn't map to a structured variant.
+    #[error("provider '{provider}' error: {message}")]
+    ProviderError {
+        /// Provider that emitted the error.
+        provider: &'static str,
+        /// Raw error message from the provider SDK.
+        message: String,
+    },
+
+    /// The command inside the sandbox did not complete within the allowed time.
+    #[error("exec timed out in sandbox {sandbox_id} after {timeout_secs}s")]
+    ExecTimeout {
+        /// Sandbox in which the timeout occurred.
+        sandbox_id: SandboxId,
+        /// Configured timeout that was exceeded.
+        timeout_secs: u64,
+    },
+
+    /// The spec requested a capability the policy does not grant.
+    #[error("capability denied: {capability}")]
+    CapabilityDenied {
+        /// Name of the denied capability bit.
+        capability: &'static str,
+    },
+
+    /// JSON serialization/deserialization error (e.g., provider metadata).
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_found_display() {
+        let err = SandboxError::NotFound(SandboxId("abc-123".into()));
+        assert_eq!(err.to_string(), "sandbox not found: abc-123");
+    }
+
+    #[test]
+    fn not_supported_display() {
+        let err = SandboxError::NotSupported { provider: "local", reason: "persistence" };
+        assert!(err.to_string().contains("persistence"));
+        assert!(err.to_string().contains("local"));
+    }
+
+    #[test]
+    fn exec_timeout_display() {
+        let err = SandboxError::ExecTimeout {
+            sandbox_id: SandboxId("s1".into()),
+            timeout_secs: 30,
+        };
+        assert!(err.to_string().contains("30s"));
+    }
+
+    #[test]
+    fn capability_denied_display() {
+        let err = SandboxError::CapabilityDenied { capability: "GPU" };
+        assert!(err.to_string().contains("GPU"));
+    }
+}

--- a/crates/arcan-sandbox/src/error.rs
+++ b/crates/arcan-sandbox/src/error.rs
@@ -65,7 +65,10 @@ mod tests {
 
     #[test]
     fn not_supported_display() {
-        let err = SandboxError::NotSupported { provider: "local", reason: "persistence" };
+        let err = SandboxError::NotSupported {
+            provider: "local",
+            reason: "persistence",
+        };
         assert!(err.to_string().contains("persistence"));
         assert!(err.to_string().contains("local"));
     }

--- a/crates/arcan-sandbox/src/event.rs
+++ b/crates/arcan-sandbox/src/event.rs
@@ -1,0 +1,142 @@
+//! Structured events emitted by the sandbox lifecycle.
+//!
+//! `SandboxEvent` is the canonical record written to Lago / SpacetimeDB for
+//! every observable sandbox state transition. Consumers can subscribe to these
+//! events for billing, audit, and observability (BRO-257).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::types::SandboxId;
+
+/// Discriminated event payload — one variant per observable lifecycle step.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SandboxEventKind {
+    /// The sandbox was accepted and provisioning began.
+    Created,
+    /// The sandbox is ready to accept `exec` calls.
+    Started,
+    /// An `exec` call completed (success or failure).
+    ExecCompleted {
+        /// Exit code returned by the process.
+        exit_code: i32,
+        /// Wall-clock milliseconds from process start to exit.
+        duration_ms: u64,
+    },
+    /// The sandbox filesystem was snapshotted.
+    Snapshotted {
+        /// Identifier of the resulting snapshot.
+        snapshot_id: String,
+    },
+    /// A previously-snapshotted sandbox was resumed.
+    Resumed {
+        /// Snapshot from which the sandbox was restored.
+        from_snapshot: String,
+    },
+    /// The sandbox was permanently destroyed.
+    Destroyed,
+    /// The sandbox encountered an unrecoverable error.
+    Failed {
+        /// Human-readable description of the failure.
+        reason: String,
+    },
+}
+
+/// A single lifecycle event for a sandbox, ready to be persisted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxEvent {
+    /// Sandbox this event belongs to.
+    pub sandbox_id: SandboxId,
+    /// Agent that owns the sandbox session.
+    pub agent_id: String,
+    /// Session within which the sandbox was created.
+    pub session_id: String,
+    /// What happened.
+    pub kind: SandboxEventKind,
+    /// Provider that emitted the event.
+    pub provider: String,
+    /// Wall-clock time of the event.
+    pub timestamp: DateTime<Utc>,
+}
+
+impl SandboxEvent {
+    /// Convenience constructor — sets `timestamp` to `Utc::now()`.
+    pub fn now(
+        sandbox_id: SandboxId,
+        agent_id: impl Into<String>,
+        session_id: impl Into<String>,
+        kind: SandboxEventKind,
+        provider: impl Into<String>,
+    ) -> Self {
+        Self {
+            sandbox_id,
+            agent_id: agent_id.into(),
+            session_id: session_id.into(),
+            kind,
+            provider: provider.into(),
+            timestamp: Utc::now(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_kind_serde_roundtrip() {
+        let kinds = [
+            SandboxEventKind::Created,
+            SandboxEventKind::Started,
+            SandboxEventKind::ExecCompleted { exit_code: 0, duration_ms: 100 },
+            SandboxEventKind::Snapshotted { snapshot_id: "snap-1".into() },
+            SandboxEventKind::Resumed { from_snapshot: "snap-1".into() },
+            SandboxEventKind::Destroyed,
+            SandboxEventKind::Failed { reason: "oom".into() },
+        ];
+        for kind in kinds {
+            let json = serde_json::to_string(&kind).unwrap();
+            let back: SandboxEventKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(kind, back);
+        }
+    }
+
+    #[test]
+    fn event_kind_tag_encoding() {
+        let kind = SandboxEventKind::Created;
+        let json = serde_json::to_string(&kind).unwrap();
+        assert!(json.contains("\"kind\":\"created\""));
+    }
+
+    #[test]
+    fn sandbox_event_now_constructor() {
+        let event = SandboxEvent::now(
+            SandboxId("s1".into()),
+            "agent-42",
+            "sess-99",
+            SandboxEventKind::Started,
+            "local",
+        );
+        assert_eq!(event.agent_id, "agent-42");
+        assert_eq!(event.session_id, "sess-99");
+        assert_eq!(event.provider, "local");
+        assert_eq!(event.kind, SandboxEventKind::Started);
+    }
+
+    #[test]
+    fn sandbox_event_serde_roundtrip() {
+        let event = SandboxEvent::now(
+            SandboxId("s2".into()),
+            "agent-1",
+            "sess-1",
+            SandboxEventKind::ExecCompleted { exit_code: 1, duration_ms: 250 },
+            "vercel",
+        );
+        let json = serde_json::to_string(&event).unwrap();
+        let back: SandboxEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event.sandbox_id, back.sandbox_id);
+        assert_eq!(event.kind, back.kind);
+        assert_eq!(event.provider, back.provider);
+    }
+}

--- a/crates/arcan-sandbox/src/event.rs
+++ b/crates/arcan-sandbox/src/event.rs
@@ -89,11 +89,20 @@ mod tests {
         let kinds = [
             SandboxEventKind::Created,
             SandboxEventKind::Started,
-            SandboxEventKind::ExecCompleted { exit_code: 0, duration_ms: 100 },
-            SandboxEventKind::Snapshotted { snapshot_id: "snap-1".into() },
-            SandboxEventKind::Resumed { from_snapshot: "snap-1".into() },
+            SandboxEventKind::ExecCompleted {
+                exit_code: 0,
+                duration_ms: 100,
+            },
+            SandboxEventKind::Snapshotted {
+                snapshot_id: "snap-1".into(),
+            },
+            SandboxEventKind::Resumed {
+                from_snapshot: "snap-1".into(),
+            },
             SandboxEventKind::Destroyed,
-            SandboxEventKind::Failed { reason: "oom".into() },
+            SandboxEventKind::Failed {
+                reason: "oom".into(),
+            },
         ];
         for kind in kinds {
             let json = serde_json::to_string(&kind).unwrap();
@@ -130,7 +139,10 @@ mod tests {
             SandboxId("s2".into()),
             "agent-1",
             "sess-1",
-            SandboxEventKind::ExecCompleted { exit_code: 1, duration_ms: 250 },
+            SandboxEventKind::ExecCompleted {
+                exit_code: 1,
+                duration_ms: 250,
+            },
             "vercel",
         );
         let json = serde_json::to_string(&event).unwrap();

--- a/crates/arcan-sandbox/src/lib.rs
+++ b/crates/arcan-sandbox/src/lib.rs
@@ -31,6 +31,7 @@ pub mod capability;
 pub mod error;
 pub mod event;
 pub mod provider;
+pub mod session_store;
 pub mod types;
 
 // Flat re-exports for ergonomic use as `arcan_sandbox::SandboxProvider`, etc.
@@ -38,6 +39,10 @@ pub use capability::SandboxCapabilitySet;
 pub use error::SandboxError;
 pub use event::{SandboxEvent, SandboxEventKind};
 pub use provider::SandboxProvider;
+pub use session_store::{
+    InMemorySessionStore, SandboxSessionStore, SandboxSessionStoreExt, UpstashSessionStore,
+    tier_ttl,
+};
 pub use types::{
     ExecRequest, ExecResult, PersistencePolicy, SandboxHandle, SandboxId, SandboxInfo,
     SandboxResources, SandboxSpec, SandboxStatus, SnapshotId,

--- a/crates/arcan-sandbox/src/lib.rs
+++ b/crates/arcan-sandbox/src/lib.rs
@@ -1,0 +1,44 @@
+//! `arcan-sandbox` — provider-agnostic sandbox execution layer.
+//!
+//! This crate defines the [`SandboxProvider`] trait and all associated
+//! protocol types. It has **zero external network dependencies** and is the
+//! single source of truth for the sandbox contract.
+//!
+//! # Architecture
+//!
+//! ```text
+//! arcan-sandbox          ← this crate: trait + types only
+//!   ├── arcan-provider-vercel   ← VercelSandboxProvider
+//!   ├── arcan-provider-e2b      ← E2BSandboxProvider
+//!   ├── arcan-provider-local    ← LocalSandboxProvider (Docker/nsjail)
+//!   └── arcan-provider-bwrap    ← BubblewrapProvider
+//! ```
+//!
+//! # Quick start
+//!
+//! ```rust,ignore
+//! use arcan_sandbox::{SandboxProvider, SandboxSpec};
+//!
+//! async fn run_hello(provider: &dyn SandboxProvider) {
+//!     let handle = provider.create(SandboxSpec::ephemeral("hello")).await.unwrap();
+//!     let result = provider.run(&handle.id, arcan_sandbox::ExecRequest::shell("echo hi")).await.unwrap();
+//!     assert_eq!(result.stdout_str().trim(), "hi");
+//!     provider.destroy(&handle.id).await.unwrap();
+//! }
+//! ```
+
+pub mod capability;
+pub mod error;
+pub mod event;
+pub mod provider;
+pub mod types;
+
+// Flat re-exports for ergonomic use as `arcan_sandbox::SandboxProvider`, etc.
+pub use capability::SandboxCapabilitySet;
+pub use error::SandboxError;
+pub use event::{SandboxEvent, SandboxEventKind};
+pub use provider::SandboxProvider;
+pub use types::{
+    ExecRequest, ExecResult, PersistencePolicy, SandboxHandle, SandboxId, SandboxInfo,
+    SandboxResources, SandboxSpec, SandboxStatus, SnapshotId,
+};

--- a/crates/arcan-sandbox/src/provider.rs
+++ b/crates/arcan-sandbox/src/provider.rs
@@ -1,0 +1,78 @@
+//! The `SandboxProvider` trait — the central abstraction for all sandbox backends.
+//!
+//! Provider implementations (Vercel, E2B, Local, Bubblewrap) live in their
+//! own crates and depend on this crate. Arcan tool code depends only on this
+//! trait; swapping providers is a configuration change, not a refactor.
+
+use async_trait::async_trait;
+
+use crate::capability::SandboxCapabilitySet;
+use crate::error::SandboxError;
+use crate::types::{
+    ExecRequest, ExecResult, SandboxHandle, SandboxId, SandboxInfo, SandboxSpec, SnapshotId,
+};
+
+/// Provider-agnostic interface for sandbox lifecycle management.
+///
+/// # Dyn-safety
+///
+/// The trait uses [`async_trait`] to make async methods object-safe. Wrap
+/// implementors in `Arc<dyn SandboxProvider>` for runtime dispatch.
+///
+/// # Provider contract
+///
+/// - `create()` returns immediately with a `SandboxHandle`; the sandbox may
+///   still be in `Starting` state. Use `list()` or a status poll to wait.
+/// - `resume()` restores a snapshotted sandbox. Providers that don't support
+///   persistence MUST return `SandboxError::NotSupported`.
+/// - `snapshot()` MUST be idempotent: calling it twice on a running sandbox
+///   produces two distinct `SnapshotId`s.
+/// - `destroy()` MUST succeed even if the sandbox is already stopped.
+#[async_trait]
+pub trait SandboxProvider: Send + Sync + 'static {
+    /// Stable, unique name used for config routing and observability labels.
+    ///
+    /// Examples: `"local"`, `"vercel"`, `"e2b"`, `"bubblewrap"`.
+    fn name(&self) -> &'static str;
+
+    /// Capability bits this provider can honour.
+    ///
+    /// Arcan checks this before forwarding a spec — any spec capability not
+    /// in this set causes `create()` to return `SandboxError::CapabilityDenied`.
+    fn capabilities(&self) -> SandboxCapabilitySet;
+
+    /// Provision a new sandbox from the given spec.
+    ///
+    /// Returns immediately once the provider has accepted the request. The
+    /// returned handle's `status` may be `Starting` if the sandbox is not
+    /// yet ready.
+    async fn create(&self, spec: SandboxSpec) -> Result<SandboxHandle, SandboxError>;
+
+    /// Resume a previously snapshotted sandbox.
+    ///
+    /// Providers that do not support persistence MUST return
+    /// [`SandboxError::NotSupported`].
+    async fn resume(&self, id: &SandboxId) -> Result<SandboxHandle, SandboxError>;
+
+    /// Execute a command inside a running sandbox and return the result.
+    ///
+    /// If the sandbox is in `Snapshotted` state the provider SHOULD
+    /// transparently resume it before executing.
+    async fn run(&self, id: &SandboxId, req: ExecRequest) -> Result<ExecResult, SandboxError>;
+
+    /// Snapshot the current filesystem state and return an opaque ID.
+    ///
+    /// The sandbox continues running after a snapshot. Use `destroy()` to
+    /// stop it.
+    async fn snapshot(&self, id: &SandboxId) -> Result<SnapshotId, SandboxError>;
+
+    /// Permanently destroy a sandbox and all associated state.
+    ///
+    /// MUST succeed even if the sandbox is already stopped or not found.
+    async fn destroy(&self, id: &SandboxId) -> Result<(), SandboxError>;
+
+    /// List all sandboxes currently visible to this provider.
+    ///
+    /// Used by `SandboxService` for periodic reconciliation (BRO-253).
+    async fn list(&self) -> Result<Vec<SandboxInfo>, SandboxError>;
+}

--- a/crates/arcan-sandbox/src/session_store.rs
+++ b/crates/arcan-sandbox/src/session_store.rs
@@ -1,0 +1,256 @@
+//! Session store abstractions for Arcan sandbox lifecycle management.
+//!
+//! This module defines the [`SandboxSessionStore`] trait and its in-process
+//! implementation [`InMemorySessionStore`]. A production Redis-backed
+//! implementation is planned in BRO-244 as a separate crate
+//! (`arcan-session-store-upstash`).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use aios_protocol::policy::SubscriptionTier;
+
+use crate::types::{SandboxHandle, SandboxId};
+
+// ── TTL policy ───────────────────────────────────────────────────────────────
+
+/// Returns the session TTL for a given [`SubscriptionTier`].
+///
+/// | Tier | TTL |
+/// |------|-----|
+/// | `Anonymous` | `Some(Duration::ZERO)` — cleared at session end via `expire()` / `remove()` |
+/// | `Free` | `Some(7 days)` |
+/// | `Pro` | `Some(90 days)` |
+/// | `Enterprise` | `None` — no expiry |
+pub fn tier_ttl(tier: SubscriptionTier) -> Option<Duration> {
+    match tier {
+        SubscriptionTier::Anonymous => Some(Duration::from_secs(0)),
+        SubscriptionTier::Free => Some(Duration::from_secs(7 * 24 * 3600)),
+        SubscriptionTier::Pro => Some(Duration::from_secs(90 * 24 * 3600)),
+        SubscriptionTier::Enterprise => None,
+    }
+}
+
+// ── Trait ────────────────────────────────────────────────────────────────────
+
+/// Maps Arcan session IDs to provider-specific backend sandbox IDs,
+/// with tier-aware TTL-based expiry.
+///
+/// Implementations:
+/// - [`InMemorySessionStore`] — in-process hash map, for development and tests.
+/// - `UpstashSessionStore` — Redis-backed, planned in BRO-244 (`arcan-session-store-upstash`).
+pub trait SandboxSessionStore: Send + Sync + 'static {
+    /// Register a mapping from `session_id` → `sandbox_id`.
+    ///
+    /// Overwrites any existing mapping for the same `session_id`.
+    /// The entry's TTL is computed from `tier` via [`tier_ttl`].
+    fn register(&self, session_id: &str, sandbox_id: SandboxId, tier: SubscriptionTier);
+
+    /// Look up the sandbox ID for `session_id`.
+    ///
+    /// Returns `None` if the entry is missing or its TTL has elapsed.
+    fn lookup(&self, session_id: &str) -> Option<SandboxId>;
+
+    /// Explicitly remove the mapping for `session_id`.
+    fn remove(&self, session_id: &str);
+
+    /// Remove all entries whose TTL has expired.
+    ///
+    /// This is intended to be called periodically by the runtime or a
+    /// background reaper task.
+    fn expire(&self);
+}
+
+// ── Convenience extension ────────────────────────────────────────────────────
+
+/// Extension methods for [`SandboxSessionStore`].
+pub trait SandboxSessionStoreExt: SandboxSessionStore {
+    /// Register a new sandbox handle, extracting the [`SandboxId`] automatically.
+    fn register_handle(&self, session_id: &str, handle: &SandboxHandle, tier: SubscriptionTier) {
+        self.register(session_id, handle.id.clone(), tier);
+    }
+}
+
+impl<T: SandboxSessionStore> SandboxSessionStoreExt for T {}
+
+// ── InMemorySessionStore ─────────────────────────────────────────────────────
+
+struct SessionEntry {
+    sandbox_id: SandboxId,
+    /// Absolute deadline after which the entry is considered expired.
+    /// `None` means the entry never expires (Enterprise tier).
+    expires_at: Option<Instant>,
+}
+
+/// In-process session store backed by a `Mutex<HashMap>`.
+///
+/// Suitable for development, tests, and single-process deployments.
+/// For multi-instance or persistent deployments use the planned
+/// `arcan-session-store-upstash` crate (BRO-244).
+pub struct InMemorySessionStore {
+    entries: Mutex<HashMap<String, SessionEntry>>,
+}
+
+impl InMemorySessionStore {
+    /// Create a new, empty session store.
+    pub fn new() -> Self {
+        Self { entries: Mutex::new(HashMap::new()) }
+    }
+}
+
+impl Default for InMemorySessionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SandboxSessionStore for InMemorySessionStore {
+    fn register(&self, session_id: &str, sandbox_id: SandboxId, tier: SubscriptionTier) {
+        let expires_at = tier_ttl(tier).map(|ttl| Instant::now() + ttl);
+        let entry = SessionEntry { sandbox_id, expires_at };
+        // Intentional: if the lock is poisoned the process is in an
+        // unrecoverable state; propagating the panic is correct here.
+        let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        map.insert(session_id.to_owned(), entry);
+    }
+
+    fn lookup(&self, session_id: &str) -> Option<SandboxId> {
+        let map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        map.get(session_id).and_then(|entry| {
+            let expired = entry.expires_at.map(|deadline| Instant::now() > deadline).unwrap_or(false);
+            if expired { None } else { Some(entry.sandbox_id.clone()) }
+        })
+    }
+
+    fn remove(&self, session_id: &str) {
+        let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        map.remove(session_id);
+    }
+
+    fn expire(&self) {
+        let now = Instant::now();
+        let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        map.retain(|_key, entry| {
+            entry.expires_at.map(|deadline| now <= deadline).unwrap_or(true)
+        });
+    }
+}
+
+// ── UpstashSessionStore stub ─────────────────────────────────────────────────
+
+/// Production session store backed by Upstash Redis.
+///
+/// Planned in BRO-244 (separate crate: `arcan-session-store-upstash`).
+/// Uses key prefix `arcan:session:` with `EXPIRE` for tier TTLs.
+pub struct UpstashSessionStore; // placeholder — not yet implemented
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{SandboxHandle, SandboxStatus};
+    use chrono::Utc;
+
+    fn make_store() -> InMemorySessionStore {
+        InMemorySessionStore::new()
+    }
+
+    fn sandbox_id(s: &str) -> SandboxId {
+        SandboxId(s.to_owned())
+    }
+
+    fn make_handle(id: &str) -> SandboxHandle {
+        SandboxHandle {
+            id: sandbox_id(id),
+            name: "test".to_owned(),
+            status: SandboxStatus::Running,
+            created_at: Utc::now(),
+            provider: "local".to_owned(),
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    // 1. Basic round-trip
+    #[test]
+    fn register_and_lookup_returns_sandbox_id() {
+        let store = make_store();
+        store.register("session-1", sandbox_id("box-1"), SubscriptionTier::Free);
+        assert_eq!(store.lookup("session-1"), Some(sandbox_id("box-1")));
+    }
+
+    // 2. Missing entry
+    #[test]
+    fn lookup_missing_returns_none() {
+        let store = make_store();
+        assert_eq!(store.lookup("does-not-exist"), None);
+    }
+
+    // 3. Explicit remove
+    #[test]
+    fn remove_clears_entry() {
+        let store = make_store();
+        store.register("session-2", sandbox_id("box-2"), SubscriptionTier::Pro);
+        store.remove("session-2");
+        assert_eq!(store.lookup("session-2"), None);
+    }
+
+    // 4. Anonymous TTL is zero-duration
+    #[test]
+    fn anonymous_tier_ttl_is_zero() {
+        assert_eq!(tier_ttl(SubscriptionTier::Anonymous), Some(Duration::from_secs(0)));
+    }
+
+    // 5. Free TTL is 7 days
+    #[test]
+    fn free_tier_ttl_is_7_days() {
+        assert_eq!(tier_ttl(SubscriptionTier::Free), Some(Duration::from_secs(7 * 24 * 3600)));
+    }
+
+    // 6. Pro TTL is 90 days
+    #[test]
+    fn pro_tier_ttl_is_90_days() {
+        assert_eq!(tier_ttl(SubscriptionTier::Pro), Some(Duration::from_secs(90 * 24 * 3600)));
+    }
+
+    // 7. Enterprise TTL is None
+    #[test]
+    fn enterprise_tier_ttl_is_none() {
+        assert_eq!(tier_ttl(SubscriptionTier::Enterprise), None);
+    }
+
+    // 8. expire() removes zero-TTL (anonymous) entries
+    #[test]
+    fn expire_removes_zero_ttl_entries() {
+        let store = make_store();
+        // Anonymous TTL = Duration::ZERO → expires_at = Instant::now() + 0 = now.
+        // By the time expire() runs, Instant::now() > that deadline (or == it).
+        // We give it a tiny sleep to be deterministic across fast machines.
+        store.register("anon-session", sandbox_id("anon-box"), SubscriptionTier::Anonymous);
+
+        // Sleep 1 ms to ensure the anonymous deadline has passed.
+        std::thread::sleep(Duration::from_millis(1));
+
+        store.expire();
+        assert_eq!(store.lookup("anon-session"), None);
+    }
+
+    // 9. expire() keeps non-expired (Free) entries alive
+    #[test]
+    fn expire_keeps_non_expired_entries() {
+        let store = make_store();
+        store.register("free-session", sandbox_id("free-box"), SubscriptionTier::Free);
+        store.expire(); // 7-day TTL — should not be removed immediately
+        assert_eq!(store.lookup("free-session"), Some(sandbox_id("free-box")));
+    }
+
+    // 10. register_handle_ext uses the SandboxHandle's id
+    #[test]
+    fn register_handle_ext() {
+        let store = make_store();
+        let handle = make_handle("handle-box");
+        store.register_handle("session-handle", &handle, SubscriptionTier::Pro);
+        assert_eq!(store.lookup("session-handle"), Some(sandbox_id("handle-box")));
+    }
+}

--- a/crates/arcan-sandbox/src/session_store.rs
+++ b/crates/arcan-sandbox/src/session_store.rs
@@ -95,7 +95,9 @@ pub struct InMemorySessionStore {
 impl InMemorySessionStore {
     /// Create a new, empty session store.
     pub fn new() -> Self {
-        Self { entries: Mutex::new(HashMap::new()) }
+        Self {
+            entries: Mutex::new(HashMap::new()),
+        }
     }
 }
 
@@ -108,31 +110,56 @@ impl Default for InMemorySessionStore {
 impl SandboxSessionStore for InMemorySessionStore {
     fn register(&self, session_id: &str, sandbox_id: SandboxId, tier: SubscriptionTier) {
         let expires_at = tier_ttl(tier).map(|ttl| Instant::now() + ttl);
-        let entry = SessionEntry { sandbox_id, expires_at };
+        let entry = SessionEntry {
+            sandbox_id,
+            expires_at,
+        };
         // Intentional: if the lock is poisoned the process is in an
         // unrecoverable state; propagating the panic is correct here.
-        let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let mut map = self
+            .entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         map.insert(session_id.to_owned(), entry);
     }
 
     fn lookup(&self, session_id: &str) -> Option<SandboxId> {
-        let map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let map = self
+            .entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         map.get(session_id).and_then(|entry| {
-            let expired = entry.expires_at.map(|deadline| Instant::now() > deadline).unwrap_or(false);
-            if expired { None } else { Some(entry.sandbox_id.clone()) }
+            let expired = entry
+                .expires_at
+                .map(|deadline| Instant::now() > deadline)
+                .unwrap_or(false);
+            if expired {
+                None
+            } else {
+                Some(entry.sandbox_id.clone())
+            }
         })
     }
 
     fn remove(&self, session_id: &str) {
-        let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let mut map = self
+            .entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         map.remove(session_id);
     }
 
     fn expire(&self) {
         let now = Instant::now();
-        let mut map = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        let mut map = self
+            .entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         map.retain(|_key, entry| {
-            entry.expires_at.map(|deadline| now <= deadline).unwrap_or(true)
+            entry
+                .expires_at
+                .map(|deadline| now <= deadline)
+                .unwrap_or(true)
         });
     }
 }
@@ -199,19 +226,28 @@ mod tests {
     // 4. Anonymous TTL is zero-duration
     #[test]
     fn anonymous_tier_ttl_is_zero() {
-        assert_eq!(tier_ttl(SubscriptionTier::Anonymous), Some(Duration::from_secs(0)));
+        assert_eq!(
+            tier_ttl(SubscriptionTier::Anonymous),
+            Some(Duration::from_secs(0))
+        );
     }
 
     // 5. Free TTL is 7 days
     #[test]
     fn free_tier_ttl_is_7_days() {
-        assert_eq!(tier_ttl(SubscriptionTier::Free), Some(Duration::from_secs(7 * 24 * 3600)));
+        assert_eq!(
+            tier_ttl(SubscriptionTier::Free),
+            Some(Duration::from_secs(7 * 24 * 3600))
+        );
     }
 
     // 6. Pro TTL is 90 days
     #[test]
     fn pro_tier_ttl_is_90_days() {
-        assert_eq!(tier_ttl(SubscriptionTier::Pro), Some(Duration::from_secs(90 * 24 * 3600)));
+        assert_eq!(
+            tier_ttl(SubscriptionTier::Pro),
+            Some(Duration::from_secs(90 * 24 * 3600))
+        );
     }
 
     // 7. Enterprise TTL is None
@@ -227,7 +263,11 @@ mod tests {
         // Anonymous TTL = Duration::ZERO → expires_at = Instant::now() + 0 = now.
         // By the time expire() runs, Instant::now() > that deadline (or == it).
         // We give it a tiny sleep to be deterministic across fast machines.
-        store.register("anon-session", sandbox_id("anon-box"), SubscriptionTier::Anonymous);
+        store.register(
+            "anon-session",
+            sandbox_id("anon-box"),
+            SubscriptionTier::Anonymous,
+        );
 
         // Sleep 1 ms to ensure the anonymous deadline has passed.
         std::thread::sleep(Duration::from_millis(1));
@@ -240,7 +280,11 @@ mod tests {
     #[test]
     fn expire_keeps_non_expired_entries() {
         let store = make_store();
-        store.register("free-session", sandbox_id("free-box"), SubscriptionTier::Free);
+        store.register(
+            "free-session",
+            sandbox_id("free-box"),
+            SubscriptionTier::Free,
+        );
         store.expire(); // 7-day TTL — should not be removed immediately
         assert_eq!(store.lookup("free-session"), Some(sandbox_id("free-box")));
     }
@@ -251,6 +295,9 @@ mod tests {
         let store = make_store();
         let handle = make_handle("handle-box");
         store.register_handle("session-handle", &handle, SubscriptionTier::Pro);
-        assert_eq!(store.lookup("session-handle"), Some(sandbox_id("handle-box")));
+        assert_eq!(
+            store.lookup("session-handle"),
+            Some(sandbox_id("handle-box"))
+        );
     }
 }

--- a/crates/arcan-sandbox/src/types.rs
+++ b/crates/arcan-sandbox/src/types.rs
@@ -1,0 +1,351 @@
+//! Core protocol types for the provider-agnostic sandbox abstraction.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::capability::SandboxCapabilitySet;
+
+// ── Identity ─────────────────────────────────────────────────────────────────
+
+/// Opaque, globally unique identifier for a sandbox instance.
+///
+/// The format is provider-dependent; treat as an opaque string.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SandboxId(pub String);
+
+impl fmt::Display for SandboxId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for SandboxId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for SandboxId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+/// Opaque identifier for a filesystem snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SnapshotId(pub String);
+
+impl fmt::Display for SnapshotId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+// ── Resource limits ───────────────────────────────────────────────────────────
+
+/// Compute resource limits for a sandbox.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxResources {
+    /// Number of virtual CPUs.
+    pub vcpus: u32,
+    /// RAM limit in megabytes.
+    pub memory_mb: u32,
+    /// Disk quota in megabytes.
+    pub disk_mb: u32,
+    /// Maximum wall-clock seconds for a single `exec` call.
+    pub timeout_secs: u64,
+}
+
+impl Default for SandboxResources {
+    fn default() -> Self {
+        Self { vcpus: 1, memory_mb: 512, disk_mb: 2048, timeout_secs: 60 }
+    }
+}
+
+// ── Persistence policy ────────────────────────────────────────────────────────
+
+/// Controls how a sandbox's filesystem is retained across sessions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PersistencePolicy {
+    /// Sandbox is destroyed when the session ends; no filesystem retention.
+    Ephemeral,
+    /// Filesystem is automatically snapshotted after `idle_timeout_secs` of
+    /// inactivity and restored on next `resume()`.
+    Persistent {
+        /// Seconds of idle time before the provider auto-snapshots.
+        ///
+        /// E2B pause has ~4 s latency per GiB RAM, so set this to at least 60.
+        idle_timeout_secs: u64,
+    },
+    /// Snapshot only when the caller explicitly invokes `snapshot()`.
+    ManualSnapshot,
+}
+
+impl Default for PersistencePolicy {
+    fn default() -> Self {
+        Self::Ephemeral
+    }
+}
+
+// ── Specification ─────────────────────────────────────────────────────────────
+
+/// Full specification used to create a new sandbox.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxSpec {
+    /// Human-readable name; used for dedup and resume lookup.
+    pub name: String,
+    /// Container / VM image reference.
+    ///
+    /// Interpretation is provider-specific:
+    /// - Local/Bubblewrap: OCI image tag (e.g., `"ubuntu:22.04"`)
+    /// - E2B: template ID
+    /// - Vercel: ignored (image selection is implicit)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    /// Compute resource limits.
+    #[serde(default)]
+    pub resources: SandboxResources,
+    /// Environment variables injected at sandbox startup.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Filesystem persistence strategy.
+    #[serde(default)]
+    pub persistence: PersistencePolicy,
+    /// Capability subset granted to this sandbox.
+    #[serde(default)]
+    pub capabilities: SandboxCapabilitySet,
+    /// Arbitrary key-value labels for routing, billing, and audit.
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+}
+
+impl SandboxSpec {
+    /// Create a minimal ephemeral spec with just a name.
+    pub fn ephemeral(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            image: None,
+            resources: SandboxResources::default(),
+            env: HashMap::new(),
+            persistence: PersistencePolicy::Ephemeral,
+            capabilities: SandboxCapabilitySet::default(),
+            labels: HashMap::new(),
+        }
+    }
+}
+
+// ── Handle & Status ───────────────────────────────────────────────────────────
+
+/// Current lifecycle state of a sandbox.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum SandboxStatus {
+    /// Sandbox is being provisioned.
+    Starting,
+    /// Sandbox is ready to accept `exec` calls.
+    Running,
+    /// Sandbox has been snapshotted and is not currently consuming resources.
+    Snapshotted,
+    /// Sandbox is in the process of being destroyed.
+    Stopping,
+    /// Sandbox has been cleanly stopped.
+    Stopped,
+    /// Sandbox encountered an unrecoverable error.
+    Failed {
+        /// Description of the failure.
+        reason: String,
+    },
+}
+
+/// A live reference to a sandbox instance returned by `create()` or `resume()`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxHandle {
+    /// Stable identifier for this sandbox.
+    pub id: SandboxId,
+    /// Human-readable name from the spec.
+    pub name: String,
+    /// Current lifecycle state.
+    pub status: SandboxStatus,
+    /// Wall clock time when the sandbox was first created.
+    pub created_at: DateTime<Utc>,
+    /// Name of the provider that owns this sandbox.
+    pub provider: String,
+    /// Provider-specific opaque metadata (serialized JSON).
+    pub metadata: serde_json::Value,
+}
+
+/// Lightweight summary used in `SandboxProvider::list()`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxInfo {
+    /// Stable identifier.
+    pub id: SandboxId,
+    /// Human-readable name.
+    pub name: String,
+    /// Current lifecycle state.
+    pub status: SandboxStatus,
+    /// Wall clock time when the sandbox was created.
+    pub created_at: DateTime<Utc>,
+}
+
+// ── Exec ──────────────────────────────────────────────────────────────────────
+
+/// A command to execute inside a running sandbox.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecRequest {
+    /// Full `argv`: `command[0]` is the executable, the rest are arguments.
+    pub command: Vec<String>,
+    /// Working directory inside the sandbox. `None` uses the provider default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_dir: Option<String>,
+    /// Additional environment variables that override the spec env.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Per-request timeout override. `None` falls back to `SandboxResources::timeout_secs`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+    /// Optional bytes written to the process's stdin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdin: Option<Vec<u8>>,
+}
+
+impl ExecRequest {
+    /// Convenience constructor for a simple shell command with no overrides.
+    pub fn shell(command: impl Into<String>) -> Self {
+        Self {
+            command: vec!["/bin/sh".into(), "-c".into(), command.into()],
+            working_dir: None,
+            env: HashMap::new(),
+            timeout_secs: None,
+            stdin: None,
+        }
+    }
+}
+
+/// The outcome of an `exec` call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecResult {
+    /// Raw bytes written to stdout.
+    pub stdout: Vec<u8>,
+    /// Raw bytes written to stderr.
+    pub stderr: Vec<u8>,
+    /// Process exit code.
+    pub exit_code: i32,
+    /// Wall-clock milliseconds from process start to exit.
+    pub duration_ms: u64,
+}
+
+impl ExecResult {
+    /// `stdout` decoded as lossy UTF-8.
+    pub fn stdout_str(&self) -> std::borrow::Cow<'_, str> {
+        String::from_utf8_lossy(&self.stdout)
+    }
+
+    /// `stderr` decoded as lossy UTF-8.
+    pub fn stderr_str(&self) -> std::borrow::Cow<'_, str> {
+        String::from_utf8_lossy(&self.stderr)
+    }
+
+    /// Returns `true` if the process exited with code 0.
+    pub fn success(&self) -> bool {
+        self.exit_code == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_id_display() {
+        assert_eq!(SandboxId("abc".into()).to_string(), "abc");
+    }
+
+    #[test]
+    fn spec_ephemeral_defaults() {
+        let spec = SandboxSpec::ephemeral("test");
+        assert_eq!(spec.name, "test");
+        assert!(spec.image.is_none());
+        assert_eq!(spec.persistence, PersistencePolicy::Ephemeral);
+        assert_eq!(spec.capabilities, SandboxCapabilitySet::FILESYSTEM_READ);
+    }
+
+    #[test]
+    fn resources_default() {
+        let r = SandboxResources::default();
+        assert_eq!(r.vcpus, 1);
+        assert_eq!(r.memory_mb, 512);
+        assert_eq!(r.disk_mb, 2048);
+        assert_eq!(r.timeout_secs, 60);
+    }
+
+    #[test]
+    fn persistence_policy_serde_roundtrip() {
+        for policy in [
+            PersistencePolicy::Ephemeral,
+            PersistencePolicy::Persistent { idle_timeout_secs: 120 },
+            PersistencePolicy::ManualSnapshot,
+        ] {
+            let json = serde_json::to_string(&policy).unwrap();
+            let back: PersistencePolicy = serde_json::from_str(&json).unwrap();
+            assert_eq!(policy, back);
+        }
+    }
+
+    #[test]
+    fn sandbox_status_serde_roundtrip() {
+        for status in [
+            SandboxStatus::Starting,
+            SandboxStatus::Running,
+            SandboxStatus::Snapshotted,
+            SandboxStatus::Stopping,
+            SandboxStatus::Stopped,
+            SandboxStatus::Failed { reason: "oom".into() },
+        ] {
+            let json = serde_json::to_string(&status).unwrap();
+            let back: SandboxStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(status, back);
+        }
+    }
+
+    #[test]
+    fn exec_request_shell_helper() {
+        let req = ExecRequest::shell("echo hello");
+        assert_eq!(req.command[0], "/bin/sh");
+        assert_eq!(req.command[2], "echo hello");
+        assert!(req.working_dir.is_none());
+        assert!(req.stdin.is_none());
+    }
+
+    #[test]
+    fn exec_result_success_and_str_helpers() {
+        let result = ExecResult {
+            stdout: b"hello\n".to_vec(),
+            stderr: vec![],
+            exit_code: 0,
+            duration_ms: 42,
+        };
+        assert!(result.success());
+        assert_eq!(result.stdout_str(), "hello\n");
+
+        let failure =
+            ExecResult { stdout: vec![], stderr: b"oops".to_vec(), exit_code: 1, duration_ms: 1 };
+        assert!(!failure.success());
+        assert_eq!(failure.stderr_str(), "oops");
+    }
+
+    #[test]
+    fn sandbox_id_serde_roundtrip() {
+        let id = SandboxId("my-sandbox-id".into());
+        let json = serde_json::to_string(&id).unwrap();
+        let back: SandboxId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, back);
+        // transparent — should serialize as plain string
+        assert_eq!(json, "\"my-sandbox-id\"");
+    }
+}

--- a/crates/arcan-sandbox/src/types.rs
+++ b/crates/arcan-sandbox/src/types.rs
@@ -63,17 +63,23 @@ pub struct SandboxResources {
 
 impl Default for SandboxResources {
     fn default() -> Self {
-        Self { vcpus: 1, memory_mb: 512, disk_mb: 2048, timeout_secs: 60 }
+        Self {
+            vcpus: 1,
+            memory_mb: 512,
+            disk_mb: 2048,
+            timeout_secs: 60,
+        }
     }
 }
 
 // ── Persistence policy ────────────────────────────────────────────────────────
 
 /// Controls how a sandbox's filesystem is retained across sessions.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum PersistencePolicy {
     /// Sandbox is destroyed when the session ends; no filesystem retention.
+    #[default]
     Ephemeral,
     /// Filesystem is automatically snapshotted after `idle_timeout_secs` of
     /// inactivity and restored on next `resume()`.
@@ -85,12 +91,6 @@ pub enum PersistencePolicy {
     },
     /// Snapshot only when the caller explicitly invokes `snapshot()`.
     ManualSnapshot,
-}
-
-impl Default for PersistencePolicy {
-    fn default() -> Self {
-        Self::Ephemeral
-    }
 }
 
 // ── Specification ─────────────────────────────────────────────────────────────
@@ -288,7 +288,9 @@ mod tests {
     fn persistence_policy_serde_roundtrip() {
         for policy in [
             PersistencePolicy::Ephemeral,
-            PersistencePolicy::Persistent { idle_timeout_secs: 120 },
+            PersistencePolicy::Persistent {
+                idle_timeout_secs: 120,
+            },
             PersistencePolicy::ManualSnapshot,
         ] {
             let json = serde_json::to_string(&policy).unwrap();
@@ -305,7 +307,9 @@ mod tests {
             SandboxStatus::Snapshotted,
             SandboxStatus::Stopping,
             SandboxStatus::Stopped,
-            SandboxStatus::Failed { reason: "oom".into() },
+            SandboxStatus::Failed {
+                reason: "oom".into(),
+            },
         ] {
             let json = serde_json::to_string(&status).unwrap();
             let back: SandboxStatus = serde_json::from_str(&json).unwrap();
@@ -333,8 +337,12 @@ mod tests {
         assert!(result.success());
         assert_eq!(result.stdout_str(), "hello\n");
 
-        let failure =
-            ExecResult { stdout: vec![], stderr: b"oops".to_vec(), exit_code: 1, duration_ms: 1 };
+        let failure = ExecResult {
+            stdout: vec![],
+            stderr: b"oops".to_vec(),
+            exit_code: 1,
+            duration_ms: 1,
+        };
         assert!(!failure.success());
         assert_eq!(failure.stderr_str(), "oops");
     }

--- a/crates/arcand/src/auth.rs
+++ b/crates/arcand/src/auth.rs
@@ -691,6 +691,9 @@ mod tests {
         };
         let token = encode_identity(&claims);
         let result = validate_identity_token(&token, TEST_SECRET);
-        assert!(result.is_ok(), "valid enterprise token should be accepted: {result:?}");
+        assert!(
+            result.is_ok(),
+            "valid enterprise token should be accepted: {result:?}"
+        );
     }
 }

--- a/crates/arcand/src/auth.rs
+++ b/crates/arcand/src/auth.rs
@@ -98,7 +98,41 @@ pub fn validate_identity_token(token: &str, secret: &str) -> Result<IdentityClai
             _ => JwtError::Invalid(e.to_string()),
         })?;
 
-    Ok(token_data.claims)
+    let claims = token_data.claims;
+
+    // Cross-field invariants that the JWT library cannot enforce:
+    //   • Enterprise tier requires `org_id` (tenant is mandatory for RBAC routing).
+    //   • Non-enterprise tiers must not carry enterprise-only claims — a forged
+    //     token that embeds org/role/capability fields while claiming a lower tier
+    //     would otherwise smuggle escalation data past the policy gate.
+    match &claims.tier {
+        Tier::Enterprise => {
+            if claims.org_id.is_none() {
+                return Err(JwtError::Invalid(
+                    "enterprise tier requires org_id".to_string(),
+                ));
+            }
+        }
+        _ => {
+            if claims.org_id.is_some() {
+                return Err(JwtError::Invalid(
+                    "org_id is only valid for enterprise tier".to_string(),
+                ));
+            }
+            if !claims.roles.is_empty() {
+                return Err(JwtError::Invalid(
+                    "roles are only valid for enterprise tier".to_string(),
+                ));
+            }
+            if claims.custom_capabilities.is_some() {
+                return Err(JwtError::Invalid(
+                    "custom_capabilities are only valid for enterprise tier".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(claims)
 }
 
 // ─── JWT Claims ──────────────────────────────────────────────────────────────
@@ -572,5 +606,91 @@ mod tests {
         let caps = claims.custom_capabilities.unwrap();
         assert_eq!(caps.len(), 2);
         assert!(caps.contains(&"fs:read:**".to_string()));
+    }
+
+    // ── Cross-field invariant tests ───────────────────────────────────────────
+
+    fn encode_identity(claims: &IdentityClaims) -> String {
+        let key = EncodingKey::from_secret(TEST_SECRET.as_bytes());
+        encode(&Header::default(), claims, &key).unwrap()
+    }
+
+    fn base_claims(tier: Tier) -> IdentityClaims {
+        IdentityClaims {
+            sub: "user-x".to_string(),
+            tier,
+            org_id: None,
+            roles: vec![],
+            custom_capabilities: None,
+            iat: 0,
+            exp: future_exp(),
+        }
+    }
+
+    #[test]
+    fn enterprise_without_org_id_is_rejected() {
+        let claims = base_claims(Tier::Enterprise); // org_id is None
+        let token = encode_identity(&claims);
+        let result = validate_identity_token(&token, TEST_SECRET);
+        assert!(
+            matches!(result, Err(JwtError::Invalid(ref msg)) if msg.contains("org_id")),
+            "expected Invalid error mentioning org_id, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn non_enterprise_with_org_id_is_rejected() {
+        let mut claims = base_claims(Tier::Pro);
+        claims.org_id = Some("org-sneaky".to_string());
+        let token = encode_identity(&claims);
+        let result = validate_identity_token(&token, TEST_SECRET);
+        assert!(
+            matches!(result, Err(JwtError::Invalid(ref msg)) if msg.contains("org_id")),
+            "expected Invalid error mentioning org_id, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn non_enterprise_with_roles_is_rejected() {
+        let mut claims = base_claims(Tier::Free);
+        claims.roles = vec![TenantRole::Admin];
+        let token = encode_identity(&claims);
+        let result = validate_identity_token(&token, TEST_SECRET);
+        assert!(
+            matches!(result, Err(JwtError::Invalid(ref msg)) if msg.contains("roles")),
+            "expected Invalid error mentioning roles, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn non_enterprise_with_custom_capabilities_is_rejected() {
+        let mut claims = base_claims(Tier::Anonymous);
+        claims.custom_capabilities = Some(vec!["fs:read:**".to_string()]);
+        let token = encode_identity(&claims);
+        let result = validate_identity_token(&token, TEST_SECRET);
+        assert!(
+            matches!(result, Err(JwtError::Invalid(ref msg)) if msg.contains("custom_capabilities")),
+            "expected Invalid error mentioning custom_capabilities, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn enterprise_with_org_id_and_roles_is_accepted() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let claims = IdentityClaims {
+            sub: "ent-admin".to_string(),
+            tier: Tier::Enterprise,
+            org_id: Some("org-valid".to_string()),
+            roles: vec![TenantRole::Admin],
+            custom_capabilities: None,
+            iat: now,
+            exp: now + 3600,
+        };
+        let token = encode_identity(&claims);
+        let result = validate_identity_token(&token, TEST_SECRET);
+        assert!(result.is_ok(), "valid enterprise token should be accepted: {result:?}");
     }
 }


### PR DESCRIPTION
## Summary

- Add `arcan-provider-bubblewrap` to workspace members (`Cargo.toml`)
- Implement `BubblewrapProvider` — a full `SandboxProvider` backed by `tokio::process::Command` with optional `bwrap` isolation when the binary is present in `PATH`
- Workspace directory model: each sandbox gets `{workspace_root}/{uuid}/`; `tokio::time::timeout` enforces per-request deadlines
- `snapshot` / `resume` via `tar -czf` / `tar -xzf` for persistence
- `capabilities()` advertises `FILESYSTEM_READ | FILESYSTEM_WRITE | PERSISTENCE`
- 9 unit tests covering: create+destroy, echo exec, exit code forwarding, timeout (`ExecTimeout` error), snapshot round-trip, resume from tarball, resume NotFound, list, and name

## Test plan

- [x] `cargo test -p arcan-provider-bubblewrap` — 9/9 pass
- [x] `cargo clippy -p arcan-provider-bubblewrap --no-deps -- -D warnings` — clean
- [x] `cargo build -p arcan-provider-bubblewrap` — clean build

Closes BRO-245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>