### PR TITLE
feat(praxis): wire VercelSandboxProvider into build_provider() — BRO-248

### DIFF
--- a/crates/arcan-praxis/Cargo.toml
+++ b/crates/arcan-praxis/Cargo.toml
@@ -20,6 +20,7 @@ arcan-harness = { path = "../arcan-harness", version = "0.2.1" }
 arcan-sandbox.workspace = true
 arcan-provider-bubblewrap.workspace = true
 arcan-provider-local.workspace = true
+arcan-provider-vercel.workspace = true
 aios-protocol.workspace = true
 praxis-core.workspace = true
 praxis-tools.workspace = true

--- a/crates/arcan-praxis/src/sandbox_runner.rs
+++ b/crates/arcan-praxis/src/sandbox_runner.rs
@@ -26,12 +26,14 @@
 //! | Value | Provider |
 //! |-------|----------|
 //! | `"local"` | [`LocalSandboxProvider`] (Docker or nsjail — falls back to bwrap on error) |
+//! | `"vercel"` | [`VercelSandboxProvider`] (Vercel Sandbox HTTP API — requires `VERCEL_TOKEN`) |
 //! | `"bubblewrap"` / `"bwrap"` / *(unset)* | [`BubblewrapProvider`] (Linux namespaces, falls back to plain subprocess) |
 
 use std::sync::Arc;
 
 use arcan_provider_bubblewrap::BubblewrapProvider;
 use arcan_provider_local::LocalSandboxProvider;
+use arcan_provider_vercel::VercelSandboxProvider;
 use arcan_sandbox::{ExecRequest, SandboxProvider, SandboxSpec};
 use praxis_core::error::{PraxisError, PraxisResult};
 use praxis_core::sandbox::{CommandRequest, CommandResult, CommandRunner, SandboxPolicy};
@@ -45,6 +47,7 @@ use tracing::{debug, warn};
 /// | `ARCAN_SANDBOX_PROVIDER` | Provider |
 /// |--------------------------|----------|
 /// | `"local"` | [`LocalSandboxProvider`] (Docker/nsjail) — falls back to bwrap if unavailable |
+/// | `"vercel"` | [`VercelSandboxProvider`] (Vercel Sandbox HTTP API) — falls back to bwrap if token missing |
 /// | `"bubblewrap"` / `"bwrap"` / *(anything else / unset)* | [`BubblewrapProvider`] |
 pub fn build_provider() -> Arc<dyn SandboxProvider> {
     let name = std::env::var("ARCAN_SANDBOX_PROVIDER").unwrap_or_default();
@@ -56,6 +59,16 @@ pub fn build_provider() -> Arc<dyn SandboxProvider> {
             }
             Err(e) => {
                 warn!(error = %e, "local provider unavailable, falling back to bubblewrap");
+                Arc::new(BubblewrapProvider::from_env())
+            }
+        },
+        "vercel" => match VercelSandboxProvider::from_env() {
+            Ok(p) => {
+                debug!("sandbox provider: vercel (Sandbox HTTP API)");
+                Arc::new(p)
+            }
+            Err(e) => {
+                warn!(error = %e, "vercel provider unavailable (missing VERCEL_TOKEN?), falling back to bubblewrap");
                 Arc::new(BubblewrapProvider::from_env())
             }
         },


### PR DESCRIPTION
## Summary
- Add `arcan-provider-vercel` as a dependency of `arcan-praxis`
- Wire `VercelSandboxProvider::from_env()` into `build_provider()` under `ARCAN_SANDBOX_PROVIDER=vercel`
- Falls back to `BubblewrapProvider` if `VERCEL_TOKEN` is missing (consistent with other providers)

## Acceptance Criteria (BRO-248)
- ✅ `VercelSandboxProvider` wired into both `arcan/sandbox_router.rs` (agent runtime) and `arcan-praxis/sandbox_runner.rs` (CommandRunner bridge)
- ✅ All 7 existing `arcan-provider-vercel` tests pass
- ✅ Provider selection via `ARCAN_SANDBOX_PROVIDER=vercel` environment variable

Closes BRO-248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vercel as a new sandbox provider option, selectable via the `ARCAN_SANDBOX_PROVIDER` environment variable
  * Provider automatically falls back to Bubblewrap if Vercel initialization fails (e.g., missing credentials)

* **Documentation**
  * Updated provider selection documentation to include Vercel option and fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->