### PR TITLE
feat(arcan): proactive context management + consolidation engine (BRO-418, BRO-421)

### DIFF
--- a/crates/arcan-commands/src/consolidate.rs
+++ b/crates/arcan-commands/src/consolidate.rs
@@ -1,0 +1,46 @@
+use crate::{Command, CommandContext, CommandResult};
+
+pub struct ConsolidateCommand;
+
+impl Command for ConsolidateCommand {
+    fn name(&self) -> &str {
+        "consolidate"
+    }
+
+    fn aliases(&self) -> &[&str] {
+        &["gc"]
+    }
+
+    fn description(&self) -> &str {
+        "Run memory consolidation (decay, pattern extraction, pruning)"
+    }
+
+    fn execute(&self, _args: &str, _ctx: &mut CommandContext) -> CommandResult {
+        CommandResult::ConsolidateRequested
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consolidate_returns_consolidate_requested() {
+        let cmd = ConsolidateCommand;
+        let mut ctx = CommandContext::default();
+        assert!(matches!(
+            cmd.execute("", &mut ctx),
+            CommandResult::ConsolidateRequested
+        ));
+    }
+
+    #[test]
+    fn consolidate_command_registered() {
+        let registry = crate::CommandRegistry::with_builtins();
+        assert!(
+            registry.has_command("consolidate"),
+            "/consolidate should be registered"
+        );
+        assert!(registry.has_command("gc"), "/gc alias should be registered");
+    }
+}

--- a/crates/arcan-commands/src/lib.rs
+++ b/crates/arcan-commands/src/lib.rs
@@ -7,6 +7,7 @@ mod clear;
 mod commit;
 mod compact;
 mod config_cmd;
+mod consolidate;
 mod context;
 mod cost;
 mod diff;
@@ -31,6 +32,8 @@ pub enum CommandResult {
     ClearSession,
     /// Compact conversation history to reduce token usage.
     CompactRequested,
+    /// Run end-of-session memory consolidation on demand.
+    ConsolidateRequested,
     /// Exit the REPL.
     Quit,
     /// An error occurred during command execution.
@@ -215,6 +218,7 @@ impl CommandRegistry {
         registry.register(Box::new(help::HelpCommand));
         registry.register(Box::new(clear::ClearCommand));
         registry.register(Box::new(compact::CompactCommand));
+        registry.register(Box::new(consolidate::ConsolidateCommand));
         registry.register(Box::new(cost::CostCommand));
         registry.register(Box::new(quit::QuitCommand));
         registry.register(Box::new(diff::DiffCommand));

--- a/crates/arcan-core/src/prompt.rs
+++ b/crates/arcan-core/src/prompt.rs
@@ -522,7 +522,12 @@ pub fn build_guidelines_section() -> String {
      - Be concise and direct in responses\n\
      - Follow existing code style and conventions\n\
      - Prefer editing existing files over creating new ones\n\
-     - Do not add features beyond what was asked"
+     - Do not add features beyond what was asked\n\n\
+     ## Context Management\n\n\
+     You have memory_offload and memory_forget tools. Use them proactively:\n\
+     - When you discover something important, offload it to memory before it gets compacted\n\
+     - When context is getting full (check /context), offload non-essential findings\n\
+     - Don't wait for auto-compact \u{2014} manage your own context budget"
         .to_string()
 }
 
@@ -766,6 +771,9 @@ mod tests {
         let guidelines = build_guidelines_section();
         assert!(guidelines.contains("Read files before editing"));
         assert!(guidelines.contains("Do not add features beyond what was asked"));
+        // BRO-418: proactive context management hints
+        assert!(guidelines.contains("memory_offload"));
+        assert!(guidelines.contains("Context Management"));
     }
 
     #[test]

--- a/crates/arcan/Cargo.toml
+++ b/crates/arcan/Cargo.toml
@@ -81,4 +81,5 @@ walkdir.workspace = true
 chrono.workspace = true
 
 [dev-dependencies]
+filetime = "0.2"
 tempfile = "3"

--- a/crates/arcan/src/consolidator.rs
+++ b/crates/arcan/src/consolidator.rs
@@ -1,0 +1,496 @@
+//! Lightweight memory consolidation engine (BRO-421).
+//!
+//! Runs on session end (graceful quit or EOF) and on `/consolidate`.
+//! Scans episodic memories for patterns, decays old unused memories,
+//! and prunes below-threshold entries.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+/// Run the full consolidation pipeline on the memory directory.
+#[allow(clippy::print_stderr)]
+pub fn consolidate(memory_dir: &Path) {
+    if !memory_dir.exists() {
+        return;
+    }
+    decay_unused_memories(memory_dir);
+    extract_patterns(memory_dir);
+    prune_low_importance(memory_dir);
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter helpers
+// ---------------------------------------------------------------------------
+
+/// Parsed frontmatter fields relevant to consolidation.
+#[derive(Debug, Default)]
+struct FrontmatterFields {
+    importance: Option<f64>,
+    access_count: Option<u64>,
+    kind: Option<String>,
+}
+
+/// Parse YAML frontmatter from a markdown file's content.
+///
+/// Returns the parsed fields and the byte offset where the body starts.
+fn parse_frontmatter(content: &str) -> (FrontmatterFields, usize) {
+    let mut fields = FrontmatterFields::default();
+
+    if !content.starts_with("---") {
+        return (fields, 0);
+    }
+
+    // Find closing `---`
+    let rest = &content[3..];
+    let Some(end) = rest.find("\n---") else {
+        return (fields, 0);
+    };
+
+    let fm_block = &rest[..end];
+    let body_start = 3 + end + 4; // skip opening `---` + fm + `\n---`
+
+    for line in fm_block.lines() {
+        let line = line.trim();
+        if let Some(val) = line.strip_prefix("importance:") {
+            fields.importance = val.trim().parse().ok();
+        } else if let Some(val) = line.strip_prefix("access_count:") {
+            fields.access_count = val.trim().parse().ok();
+        } else if let Some(val) = line.strip_prefix("kind:") {
+            fields.kind = Some(val.trim().to_string());
+        }
+    }
+
+    (fields, body_start)
+}
+
+/// Rewrite the `importance` value in the frontmatter of `content`.
+///
+/// If the file has a frontmatter block with an `importance:` key, the value
+/// is replaced in-place. If there is no frontmatter, one is prepended.
+fn set_importance(content: &str, new_importance: f64) -> String {
+    let val_str = format!("{new_importance:.2}");
+
+    if let Some(rest) = content.strip_prefix("---") {
+        // Try to replace existing importance line
+        let has_importance = content.lines().any(|l| l.trim().starts_with("importance:"));
+        if has_importance {
+            let rebuilt: Vec<String> = content
+                .lines()
+                .map(|l| {
+                    if l.trim().starts_with("importance:") {
+                        format!("importance: {val_str}")
+                    } else {
+                        l.to_string()
+                    }
+                })
+                .collect();
+            return rebuilt.join("\n");
+        }
+        // Frontmatter exists but no importance key — insert before closing ---
+        if let Some(end) = rest.find("\n---") {
+            let fm = &rest[..end];
+            let after = &rest[end + 4..];
+            return format!("---{fm}\nimportance: {val_str}\n---{after}");
+        }
+    }
+
+    // No frontmatter — prepend one
+    format!("---\nimportance: {val_str}\n---\n{content}")
+}
+
+// ---------------------------------------------------------------------------
+// Consolidation passes
+// ---------------------------------------------------------------------------
+
+/// Reduce importance of memories not accessed recently.
+///
+/// For each `.md` file in the memory directory: if the file has not been
+/// modified in the last 7 days and its importance is above 0.3, reduce
+/// importance by 0.1.
+#[allow(clippy::print_stderr)]
+fn decay_unused_memories(memory_dir: &Path) {
+    let Ok(entries) = fs::read_dir(memory_dir) else {
+        return;
+    };
+
+    let seven_days_ago = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(7 * 24 * 3600))
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+
+    let mut decayed = 0u32;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.extension().is_some_and(|e| e == "md") {
+            continue;
+        }
+        // Skip the index file itself
+        if path.file_name().is_some_and(|n| n == "MEMORY.md") {
+            continue;
+        }
+
+        let Ok(metadata) = fs::metadata(&path) else {
+            continue;
+        };
+        let mtime = metadata
+            .modified()
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+
+        if mtime > seven_days_ago {
+            continue; // Recently modified — skip
+        }
+
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+
+        let (fields, _) = parse_frontmatter(&content);
+        let importance = fields.importance.unwrap_or(0.5);
+
+        if importance > 0.3 {
+            let new_importance = (importance - 0.1).max(0.0);
+            let updated = set_importance(&content, new_importance);
+            if fs::write(&path, updated).is_ok() {
+                decayed += 1;
+            }
+        }
+    }
+
+    if decayed > 0 {
+        eprintln!("[consolidate] Decayed {decayed} memories");
+    }
+}
+
+/// Look for repeated patterns across episodic memories.
+///
+/// Reads all `session_summary*.md` files and looks for keywords that
+/// appear in 3+ summaries. Creates a semantic memory for each pattern.
+#[allow(clippy::print_stderr)]
+fn extract_patterns(memory_dir: &Path) {
+    let Ok(entries) = fs::read_dir(memory_dir) else {
+        return;
+    };
+
+    let mut summaries = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        if name.starts_with("session_summary") && name.ends_with(".md") {
+            if let Ok(content) = fs::read_to_string(&path) {
+                summaries.push(content);
+            }
+        }
+    }
+
+    if summaries.len() < 3 {
+        return; // Not enough data for pattern detection
+    }
+
+    // Count word frequency across summaries (only meaningful words)
+    let mut word_counts: HashMap<String, u32> = HashMap::new();
+    let stop_words = [
+        "the", "a", "an", "is", "are", "was", "were", "be", "been", "being", "have", "has", "had",
+        "do", "does", "did", "will", "would", "could", "should", "may", "might", "shall", "can",
+        "to", "of", "in", "for", "on", "with", "at", "by", "from", "as", "into", "through",
+        "during", "before", "after", "above", "below", "between", "this", "that", "these", "those",
+        "it", "its", "and", "or", "but", "not", "no", "if", "then", "else", "when", "up", "out",
+        "so", "than", "too", "very", "just", "about", "all", "each",
+    ];
+
+    for summary in &summaries {
+        // Track words seen in THIS summary to count per-document frequency
+        let mut seen_in_doc = std::collections::HashSet::new();
+        for word in summary.split_whitespace() {
+            let clean: String = word
+                .to_lowercase()
+                .chars()
+                .filter(|c| c.is_alphanumeric())
+                .collect();
+            if clean.len() >= 4
+                && !stop_words.contains(&clean.as_str())
+                && seen_in_doc.insert(clean.clone())
+            {
+                *word_counts.entry(clean).or_default() += 1;
+            }
+        }
+    }
+
+    // Find words appearing in 3+ summaries
+    let patterns: Vec<(&String, &u32)> = word_counts
+        .iter()
+        .filter(|(_, count)| **count >= 3)
+        .collect();
+
+    if patterns.is_empty() {
+        return;
+    }
+
+    let mut extracted = 0u32;
+    for (keyword, count) in &patterns {
+        let pattern_file = memory_dir.join(format!("pattern_{keyword}.md"));
+        if pattern_file.exists() {
+            continue; // Already extracted
+        }
+        let content = format!(
+            "---\ntype: semantic\nkind: consolidate\nimportance: 0.4\naccess_count: 0\n---\n\
+             # Pattern: {keyword}\n\n\
+             Appears in {count} session summaries. This is a recurring theme in agent sessions.\n"
+        );
+        if fs::write(&pattern_file, content).is_ok() {
+            extracted += 1;
+        }
+    }
+
+    if extracted > 0 {
+        eprintln!("[consolidate] Extracted {extracted} patterns");
+    }
+}
+
+/// Remove memories below importance threshold.
+///
+/// Deletes `.md` files where importance < 0.05, access_count == 0, and
+/// the file hasn't been modified in 30+ days.
+#[allow(clippy::print_stderr)]
+fn prune_low_importance(memory_dir: &Path) {
+    let Ok(entries) = fs::read_dir(memory_dir) else {
+        return;
+    };
+
+    let thirty_days_ago = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(30 * 24 * 3600))
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+
+    let mut pruned = 0u32;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.extension().is_some_and(|e| e == "md") {
+            continue;
+        }
+        if path.file_name().is_some_and(|n| n == "MEMORY.md") {
+            continue;
+        }
+
+        let Ok(metadata) = fs::metadata(&path) else {
+            continue;
+        };
+        let mtime = metadata
+            .modified()
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+
+        if mtime > thirty_days_ago {
+            continue; // Too recent to prune
+        }
+
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+
+        let (fields, _) = parse_frontmatter(&content);
+        let importance = fields.importance.unwrap_or(0.5);
+        let access_count = fields.access_count.unwrap_or(1);
+
+        if importance < 0.05 && access_count == 0 {
+            let file_name = path.file_name().unwrap_or_default().to_string_lossy();
+            if fs::remove_file(&path).is_ok() {
+                eprintln!("[consolidate] Pruned {file_name}");
+                pruned += 1;
+            }
+        }
+    }
+
+    if pruned > 0 {
+        eprintln!("[consolidate] Pruned {pruned} total memories");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_frontmatter_with_importance() {
+        let content = "---\nimportance: 0.7\naccess_count: 3\nkind: episodic\n---\n# Hello\nBody";
+        let (fields, body_start) = parse_frontmatter(content);
+        assert!((fields.importance.unwrap() - 0.7).abs() < f64::EPSILON);
+        assert_eq!(fields.access_count, Some(3));
+        assert_eq!(fields.kind.as_deref(), Some("episodic"));
+        assert!(body_start > 0);
+    }
+
+    #[test]
+    fn test_parse_frontmatter_missing() {
+        let content = "# No frontmatter\nJust body.";
+        let (fields, body_start) = parse_frontmatter(content);
+        assert!(fields.importance.is_none());
+        assert_eq!(body_start, 0);
+    }
+
+    #[test]
+    fn test_set_importance_existing() {
+        let content = "---\nimportance: 0.7\nkind: episodic\n---\n# Hello";
+        let updated = set_importance(content, 0.3);
+        assert!(updated.contains("importance: 0.30"));
+        assert!(updated.contains("kind: episodic"));
+    }
+
+    #[test]
+    fn test_set_importance_no_frontmatter() {
+        let content = "# Hello\nBody text.";
+        let updated = set_importance(content, 0.5);
+        assert!(updated.starts_with("---\nimportance: 0.50\n---\n"));
+        assert!(updated.contains("# Hello"));
+    }
+
+    #[test]
+    fn test_decay_reduces_importance() {
+        let dir = tempfile::tempdir().unwrap();
+        let mem_dir = dir.path().join("memory");
+        fs::create_dir_all(&mem_dir).unwrap();
+
+        // Create a memory file with high importance
+        let mem_file = mem_dir.join("old_memory.md");
+        fs::write(
+            &mem_file,
+            "---\nimportance: 0.8\naccess_count: 0\n---\n# Old memory\nSome content.",
+        )
+        .unwrap();
+
+        // Set mtime to 10 days ago
+        let ten_days_ago = std::time::SystemTime::now()
+            .checked_sub(std::time::Duration::from_secs(10 * 24 * 3600))
+            .unwrap();
+        filetime::set_file_mtime(
+            &mem_file,
+            filetime::FileTime::from_system_time(ten_days_ago),
+        )
+        .unwrap();
+
+        decay_unused_memories(&mem_dir);
+
+        let content = fs::read_to_string(&mem_file).unwrap();
+        let (fields, _) = parse_frontmatter(&content);
+        let importance = fields.importance.unwrap();
+        // Should have been reduced from 0.8 to 0.7
+        assert!(
+            (importance - 0.7).abs() < 0.01,
+            "Expected ~0.7, got {importance}"
+        );
+    }
+
+    #[test]
+    fn test_prune_removes_low_importance() {
+        let dir = tempfile::tempdir().unwrap();
+        let mem_dir = dir.path().join("memory");
+        fs::create_dir_all(&mem_dir).unwrap();
+
+        // Create a low-importance, zero-access memory
+        let mem_file = mem_dir.join("stale.md");
+        fs::write(
+            &mem_file,
+            "---\nimportance: 0.01\naccess_count: 0\n---\n# Stale\nNot useful.",
+        )
+        .unwrap();
+
+        // Set mtime to 60 days ago
+        let sixty_days_ago = std::time::SystemTime::now()
+            .checked_sub(std::time::Duration::from_secs(60 * 24 * 3600))
+            .unwrap();
+        filetime::set_file_mtime(
+            &mem_file,
+            filetime::FileTime::from_system_time(sixty_days_ago),
+        )
+        .unwrap();
+
+        prune_low_importance(&mem_dir);
+
+        assert!(!mem_file.exists(), "Stale file should have been pruned");
+    }
+
+    #[test]
+    fn test_prune_keeps_important_memories() {
+        let dir = tempfile::tempdir().unwrap();
+        let mem_dir = dir.path().join("memory");
+        fs::create_dir_all(&mem_dir).unwrap();
+
+        // Create a memory with decent importance
+        let mem_file = mem_dir.join("important.md");
+        fs::write(
+            &mem_file,
+            "---\nimportance: 0.5\naccess_count: 0\n---\n# Important\nKeep this.",
+        )
+        .unwrap();
+
+        // Even if old
+        let sixty_days_ago = std::time::SystemTime::now()
+            .checked_sub(std::time::Duration::from_secs(60 * 24 * 3600))
+            .unwrap();
+        filetime::set_file_mtime(
+            &mem_file,
+            filetime::FileTime::from_system_time(sixty_days_ago),
+        )
+        .unwrap();
+
+        prune_low_importance(&mem_dir);
+
+        assert!(mem_file.exists(), "Important file should be kept");
+    }
+
+    #[test]
+    fn test_consolidate_on_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let mem_dir = dir.path().join("memory");
+        fs::create_dir_all(&mem_dir).unwrap();
+
+        // Should not panic
+        consolidate(&mem_dir);
+    }
+
+    #[test]
+    fn test_consolidate_on_nonexistent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let mem_dir = dir.path().join("nonexistent");
+
+        // Should not panic
+        consolidate(&mem_dir);
+    }
+
+    #[test]
+    fn test_extract_patterns_creates_semantic_memories() {
+        let dir = tempfile::tempdir().unwrap();
+        let mem_dir = dir.path().join("memory");
+        fs::create_dir_all(&mem_dir).unwrap();
+
+        // Create 4 session summaries that all mention "refactoring"
+        for i in 0..4 {
+            fs::write(
+                mem_dir.join(format!("session_summary_{i}.md")),
+                format!(
+                    "# Session Summary\n\n- Completed refactoring of module {i}\n- Fixed tests\n"
+                ),
+            )
+            .unwrap();
+        }
+
+        extract_patterns(&mem_dir);
+
+        let pattern_file = mem_dir.join("pattern_refactoring.md");
+        assert!(
+            pattern_file.exists(),
+            "Pattern file for 'refactoring' should exist"
+        );
+        let content = fs::read_to_string(&pattern_file).unwrap();
+        assert!(content.contains("kind: consolidate"));
+        assert!(content.contains("type: semantic"));
+    }
+}

--- a/crates/arcan/src/main.rs
+++ b/crates/arcan/src/main.rs
@@ -1,5 +1,6 @@
 mod cli_run;
 mod config;
+mod consolidator;
 mod daemon;
 mod ephemeral_journal;
 mod factory;

--- a/crates/arcan/src/shell.rs
+++ b/crates/arcan/src/shell.rs
@@ -241,6 +241,73 @@ fn compact_conversation(messages: &mut Vec<ChatMessage>, target: usize) {
     *messages = kept;
 }
 
+/// Compact conversation with simultaneous memory extraction (BRO-418).
+///
+/// This is the reactive backstop: when auto-compact fires or `/compact` is used,
+/// we extract memories from the FULL conversation before compressing it.
+/// The proactive mechanism is the `memory_offload` tool the agent can call anytime.
+#[allow(clippy::print_stderr)]
+fn compact_with_extraction(
+    messages: &mut Vec<ChatMessage>,
+    memory_dir: &Path,
+    target_tokens: usize,
+) {
+    // 1. BEFORE compacting, extract insights from the FULL conversation
+    //    (this is the last chance to see the uncompressed messages)
+    extract_and_save_memories(messages, memory_dir);
+
+    // 2. Update MEMORY.md index with any new memories
+    arcan_core::prompt::write_memory_index(memory_dir);
+
+    // 3. MicroCompact: shrink verbose tool outputs in-place
+    micro_compact(messages);
+
+    // 4. THEN compact the conversation (remove old messages)
+    compact_conversation(messages, target_tokens);
+
+    // 5. Log as EGRI signal
+    eprintln!(
+        "[compact] \u{26a0} Emergency compaction triggered. \
+         Consider using memory_offload proactively."
+    );
+}
+
+/// Compress individual tool outputs in-place (Bash, FileRead, Grep).
+///
+/// Reduces verbose outputs without removing messages. This is a lightweight
+/// pre-pass that shrinks oversized content before the main compaction removes
+/// entire messages.
+fn micro_compact(messages: &mut [ChatMessage]) {
+    use arcan_core::protocol::Role;
+
+    for msg in messages.iter_mut() {
+        if msg.role != Role::User {
+            continue;
+        }
+
+        let content = &msg.content;
+
+        // Truncate bash outputs over 2K chars
+        if content.len() > 2000 && (content.contains("exit code:") || content.contains("stdout:")) {
+            let truncated = format!(
+                "{}...\n[output truncated from {} to 2000 chars]",
+                &content[..2000],
+                content.len()
+            );
+            msg.content = truncated;
+            continue;
+        }
+
+        // Truncate file read outputs over 4K chars (tab-prefixed numbered lines)
+        if content.len() > 4000 && content.contains('\t') && content.lines().count() > 50 {
+            let lines: Vec<&str> = content.lines().collect();
+            let kept = lines[..30].join("\n");
+            let truncated = format!("{}\n...[{} lines truncated to 30]", kept, lines.len());
+            msg.content = truncated;
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Lago journal helpers (BRO-356 / BRO-357)
 // ---------------------------------------------------------------------------
@@ -1099,9 +1166,15 @@ pub fn run_shell(
                 }
                 Some(CommandResult::CompactRequested) => {
                     let before = estimate_tokens(&messages);
-                    compact_conversation(&mut messages, COMPACT_TARGET);
+                    compact_with_extraction(&mut messages, &memory_dir, COMPACT_TARGET);
                     let after = estimate_tokens(&messages);
                     eprintln!("[compact] {before} tokens -> {after} tokens");
+                }
+                Some(CommandResult::ConsolidateRequested) => {
+                    eprintln!("[consolidate] Running on-demand consolidation...");
+                    crate::consolidator::consolidate(&memory_dir);
+                    arcan_core::prompt::write_memory_index(&memory_dir);
+                    eprintln!("[consolidate] Done.");
                 }
                 Some(CommandResult::Quit) => {
                     eprintln!("Goodbye.");
@@ -1181,10 +1254,6 @@ pub fn run_shell(
                 }
                 // Update message count after loop completes
                 cmd_ctx.message_count = messages.len();
-                // Extract and save key facts from this turn to persistent memory.
-                extract_and_save_memories(&messages, &memory_dir);
-                // Regenerate MEMORY.md index after memory extraction (BRO-419)
-                crate::prompt::write_memory_index(&memory_dir);
 
                 // --- BRO-385: Write session turn summary to workspace journal ---
                 if let Some(ref wj) = workspace_journal {
@@ -1231,10 +1300,16 @@ pub fn run_shell(
         let tokens = estimate_tokens(&messages);
         if tokens > COMPACT_THRESHOLD {
             eprintln!("[compact] {tokens} tokens -> compacting to ~{COMPACT_TARGET}");
-            compact_conversation(&mut messages, COMPACT_TARGET);
+            compact_with_extraction(&mut messages, &memory_dir, COMPACT_TARGET);
             eprintln!("[compact] now ~{} tokens", estimate_tokens(&messages));
         }
     }
+
+    // --- End-of-session consolidation (BRO-421) ---
+    eprintln!("[consolidate] Running end-of-session consolidation...");
+    crate::consolidator::consolidate(&memory_dir);
+    arcan_core::prompt::write_memory_index(&memory_dir);
+    eprintln!("[consolidate] Done.");
 
     // --- Fire SessionEnd hooks ---
     if !hook_registry.is_empty() {
@@ -2057,5 +2132,109 @@ mod tests {
         assert_eq!(IdentityTier::Free.to_string(), "free");
         assert_eq!(IdentityTier::Pro.to_string(), "pro");
         assert_eq!(IdentityTier::Enterprise.to_string(), "enterprise");
+    }
+
+    // --- BRO-418: MicroCompact tests ---
+
+    #[test]
+    fn test_micro_compact_truncates_bash() {
+        let long_output = format!("stdout: {}\nexit code: 0", "x".repeat(3000));
+        let mut messages = vec![make_msg(Role::User, &long_output)];
+        micro_compact(&mut messages);
+
+        assert!(
+            messages[0].content.len() < long_output.len(),
+            "Bash output should be truncated"
+        );
+        assert!(messages[0].content.contains("[output truncated from"));
+    }
+
+    #[test]
+    fn test_micro_compact_truncates_file_read() {
+        // Simulate a long file read with tab-prefixed numbered lines
+        let lines: Vec<String> = (1..=100)
+            .map(|i| {
+                format!(
+                    "{i}\tlet x = {i}; // some code that fills out the line with content padding"
+                )
+            })
+            .collect();
+        let long_read = lines.join("\n");
+        let mut messages = vec![make_msg(Role::User, &long_read)];
+        micro_compact(&mut messages);
+
+        assert!(
+            messages[0].content.contains("lines truncated to 30"),
+            "File read output should be truncated"
+        );
+    }
+
+    #[test]
+    fn test_micro_compact_leaves_short_output() {
+        let short = "stdout: hello\nexit code: 0";
+        let mut messages = vec![make_msg(Role::User, short)];
+        let original = messages[0].content.clone();
+        micro_compact(&mut messages);
+
+        assert_eq!(
+            messages[0].content, original,
+            "Short output should be unchanged"
+        );
+    }
+
+    #[test]
+    fn test_micro_compact_skips_assistant_messages() {
+        let long_output = format!("stdout: {}\nexit code: 0", "x".repeat(3000));
+        let mut messages = vec![make_msg(Role::Assistant, &long_output)];
+        let original = messages[0].content.clone();
+        micro_compact(&mut messages);
+
+        assert_eq!(
+            messages[0].content, original,
+            "Assistant messages should not be micro-compacted"
+        );
+    }
+
+    #[test]
+    fn test_compact_with_extraction_creates_memories() {
+        let dir = std::env::temp_dir().join(format!(
+            "arcan-compact-extract-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        let mut messages = vec![
+            make_msg(Role::User, "Investigate the bug"),
+            make_msg(
+                Role::Assistant,
+                "- Found the root cause in the retry logic\n\
+                 - Fixed by adding exponential backoff\n\
+                 Modified crates/arcan/src/shell.rs",
+            ),
+            make_msg(Role::User, "Thanks"),
+            make_msg(Role::Assistant, "You're welcome."),
+        ];
+
+        compact_with_extraction(&mut messages, &dir, 200);
+
+        // Memories should have been extracted
+        let summary_path = dir.join("session_summary.md");
+        assert!(
+            summary_path.exists(),
+            "Session summary should be created during compact"
+        );
+        let content = std::fs::read_to_string(&summary_path).unwrap();
+        assert!(content.contains("root cause"));
+
+        // MEMORY.md index should also exist
+        let index_path = dir.join("MEMORY.md");
+        assert!(
+            index_path.exists(),
+            "MEMORY.md index should be created during compact"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 }


### PR DESCRIPTION
## Summary

- **BRO-418**: Smart compaction with memory extraction — removes per-turn extraction (now uses `memory_offload` tool for proactive saving), adds `compact_with_extraction` that extracts memories before compressing, adds `micro_compact` to shrink verbose tool outputs in-place, and adds proactive context management hints to agent guidelines
- **BRO-421**: Consolidation engine — `consolidator.rs` runs on session end with decay (reduce importance of stale memories), pattern extraction (detect recurring keywords across session summaries), and pruning (remove memories below importance threshold). Manual trigger via `/consolidate` (alias `/gc`)
- 14 new tests across 3 crates; all 250 tests pass; `cargo check` and `cargo clippy` clean (pre-existing warnings only in `context.rs`)

## Test plan

- [x] `cargo check -p arcan -p arcan-commands -p arcan-core` passes
- [x] `cargo clippy -p arcan -p arcan-core` — no new warnings
- [x] `cargo test -p arcan -p arcan-commands -p arcan-core` — 250 tests pass
- [x] `cargo fmt --all` applied
- [ ] Manual test: run `arcan shell`, use `/compact` and verify memory extraction + MEMORY.md update
- [ ] Manual test: run `/consolidate` and verify decay/pattern/prune output
- [ ] Manual test: verify auto-compact at threshold triggers extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)