### PR TITLE
feat(arcand): freeze session prompt prefixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,8 @@ version = "0.2.0"
 dependencies = [
  "aios-protocol",
  "anyhow",
+ "async-trait",
+ "blake3",
  "chrono",
  "hex",
  "life-vigil",
@@ -1000,6 +1002,7 @@ name = "autonomic-controller"
 version = "0.1.0"
 dependencies = [
  "aios-protocol",
+ "anima-core",
  "autonomic-core",
  "chrono",
  "serde",
@@ -1012,6 +1015,7 @@ name = "autonomic-core"
 version = "0.1.0"
 dependencies = [
  "aios-protocol",
+ "anima-core",
  "chrono",
  "serde",
  "serde_json",

--- a/crates/arcand/src/canonical.rs
+++ b/crates/arcand/src/canonical.rs
@@ -1,4 +1,10 @@
-use std::{convert::Infallible, sync::Arc, time::Duration, time::Instant};
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    sync::{Arc, Mutex},
+    time::Duration,
+    time::Instant,
+};
 
 use arcan_aios_adapters::tools::ToolHarnessObserver;
 
@@ -213,6 +219,13 @@ struct CanonicalState {
     /// In-memory token-bucket rate limiter (BRO-223).
     /// Shared across all request handlers via `Arc`.
     rate_limiter: Arc<crate::rate_limit::RateLimiter>,
+    /// Frozen per-session prompt prefixes for provider cache preservation (BRO-424).
+    frozen_prompt_prefixes: Arc<Mutex<HashMap<String, FrozenPromptPrefix>>>,
+}
+
+#[derive(Debug, Clone)]
+struct FrozenPromptPrefix {
+    system_prompt_prefix: String,
 }
 
 #[derive(Debug, Deserialize, Default, ToSchema)]
@@ -636,6 +649,7 @@ pub fn create_canonical_router_with_skills(
         free_tier_journal,
         anima_secret,
         rate_limiter: Arc::new(crate::rate_limit::RateLimiter::new()),
+        frozen_prompt_prefixes: Arc::new(Mutex::new(HashMap::new())),
     };
 
     let auth_config = Arc::new(AuthConfig::from_env());
@@ -1420,10 +1434,10 @@ async fn run_session(
         .map(|registry| build_tiered_skill_catalog(registry, tier_allowed_tools.as_deref()))
         .unwrap_or_default();
 
-    // BRO-366/374/375: Build unified liquid prompt — git context, project instructions,
-    // environment, memory, persona, skill catalog, and guidelines.
+    // Build the stable system-prompt prefix once per session so mid-session
+    // memory, git context, or skill-registry changes do not invalidate provider
+    // prompt caches. Dynamic active-skill prompts remain appended per turn.
     let persona = state.identity.persona_block();
-    // Append sandbox workspace note to persona so the LLM knows where to write files.
     let sandbox_note = sandbox_path
         .as_ref()
         .map(|p| {
@@ -1435,60 +1449,32 @@ async fn run_session(
             )
         })
         .unwrap_or_default();
-
-    let system_prompt = Some({
-        let mut sections = Vec::new();
-
-        // 1. Persona (agent identity)
-        sections.push(format!("{persona}{sandbox_note}"));
-
-        // 2. Environment info (BRO-366)
-        let provider_name = state
-            .provider_handle
-            .read()
-            .ok()
-            .map(|p| p.name().to_string())
-            .unwrap_or_else(|| "unknown".to_string());
-        let model_name = std::env::var("ARCAN_MODEL")
-            .or_else(|_| std::env::var("MODEL"))
-            .unwrap_or_else(|_| "default".to_string());
-        sections.push(arcan_core::prompt::build_environment_section(
+    let provider_name = state
+        .provider_handle
+        .read()
+        .ok()
+        .map(|p| p.name().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let model_name = std::env::var("ARCAN_MODEL")
+        .or_else(|_| std::env::var("MODEL"))
+        .unwrap_or_else(|_| "default".to_string());
+    let frozen_prompt_prefix = state.frozen_prompt_prefix(
+        session_id.as_str(),
+        build_system_prompt_prefix(
             &state.workspace_root,
+            state.cached_project_instructions.as_deref(),
+            &state.data_dir.join("memory"),
             &provider_name,
             &model_name,
-        ));
-
-        // 3. Git context (BRO-374) — computed per-request for freshness
-        if let Some(git) = arcan_core::prompt::build_git_section(&state.workspace_root) {
-            sections.push(git);
-        }
-
-        // 4. Project instructions (BRO-375) — cached at startup
-        if let Some(ref instructions) = state.cached_project_instructions {
-            sections.push(format!("# Project Instructions\n\n{instructions}"));
-        }
-
-        // 5. Memory (from data_dir)
-        let memory_dir = state.data_dir.join("memory");
-        if let Some(memory) = arcan_core::prompt::build_memory_section(&memory_dir) {
-            sections.push(memory);
-        }
-
-        // 6. Tier-filtered skill catalog
-        if !skill_catalog.is_empty() {
-            sections.push(skill_catalog);
-        }
-
-        // 7. Active skill prompt
-        if let Some(skill) = skill_prompt {
-            sections.push(skill);
-        }
-
-        // 8. Guidelines
-        sections.push(arcan_core::prompt::build_guidelines_section());
-
-        sections.join("\n\n---\n\n")
-    });
+            &skill_catalog,
+            &persona,
+            &sandbox_note,
+        ),
+    );
+    let system_prompt = Some(append_prompt_suffix(
+        &frozen_prompt_prefix.system_prompt_prefix,
+        skill_prompt.as_deref(),
+    ));
 
     // Combine tier restriction with any active skill's allowed_tools.
     // When both restrict, use their intersection (more restrictive always wins).
@@ -1657,6 +1643,71 @@ async fn extract_run_context(
     };
 
     (final_answer, messages)
+}
+
+fn build_system_prompt_prefix(
+    workspace_root: &std::path::Path,
+    cached_project_instructions: Option<&str>,
+    memory_dir: &std::path::Path,
+    provider_name: &str,
+    model_name: &str,
+    skill_catalog: &str,
+    persona: &str,
+    sandbox_note: &str,
+) -> String {
+    let mut sections = Vec::new();
+
+    sections.push(format!("{persona}{sandbox_note}"));
+    sections.push(arcan_core::prompt::build_environment_section(
+        workspace_root,
+        provider_name,
+        model_name,
+    ));
+
+    if let Some(git) = arcan_core::prompt::build_git_section(workspace_root) {
+        sections.push(git);
+    }
+
+    if let Some(instructions) = cached_project_instructions {
+        sections.push(format!("# Project Instructions\n\n{instructions}"));
+    }
+
+    if let Some(memory) = arcan_core::prompt::build_memory_section(memory_dir) {
+        sections.push(memory);
+    }
+
+    if !skill_catalog.is_empty() {
+        sections.push(skill_catalog.to_owned());
+    }
+
+    sections.push(arcan_core::prompt::build_guidelines_section());
+    sections.join("\n\n---\n\n")
+}
+
+fn append_prompt_suffix(prefix: &str, suffix: Option<&str>) -> String {
+    match suffix {
+        Some(suffix) => format!("{prefix}\n\n---\n\n{suffix}"),
+        None => prefix.to_owned(),
+    }
+}
+
+impl CanonicalState {
+    fn frozen_prompt_prefix(
+        &self,
+        session_id: &str,
+        computed_prefix: String,
+    ) -> FrozenPromptPrefix {
+        let mut prefixes = self
+            .frozen_prompt_prefixes
+            .lock()
+            .expect("frozen prompt prefix cache poisoned");
+        prefixes
+            .entry(session_id.to_owned())
+            .or_insert_with(|| FrozenPromptPrefix {
+                system_prompt_prefix: computed_prefix,
+            })
+            .clone()
+    }
 }
 
 #[utoipa::path(

--- a/crates/arcand/tests/canonical_api.rs
+++ b/crates/arcand/tests/canonical_api.rs
@@ -1,19 +1,23 @@
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use aios_events::{EventJournal, EventStreamHub, FileEventStore};
 use aios_policy::{ApprovalQueue, SessionPolicyEngine};
 use aios_protocol::{
-    ApprovalPort, EventStorePort, KernelResult, ModelCompletion, ModelCompletionRequest,
-    ModelDirective, ModelProviderPort, ModelStopReason, PolicyGatePort, PolicySet, ToolHarnessPort,
+    AgentId, AgentIdentityProvider, ApprovalPort, EventStorePort, KernelResult, ModelCompletion,
+    ModelCompletionRequest, ModelDirective, ModelProviderPort, ModelStopReason, PolicyGatePort,
+    PolicySet, SoulProfile, ToolHarnessPort,
 };
 use aios_runtime::{KernelRuntime, RuntimeConfig};
 use aios_sandbox::LocalSandboxRunner;
 use aios_tools::{ToolDispatcher, ToolRegistry};
 use arcan_core::error::CoreError;
 use arcan_core::runtime::{Provider, ProviderFactory, SwappableProviderHandle};
-use arcand::canonical::{create_canonical_router, openapi_spec};
+use arcand::canonical::{
+    create_canonical_router, create_canonical_router_with_skills, openapi_spec,
+};
 use async_trait::async_trait;
 use reqwest::StatusCode;
 use serde_json::json;
@@ -76,6 +80,74 @@ impl ModelProviderPort for TestProvider {
     }
 }
 
+#[derive(Debug, Clone)]
+struct CapturingProvider {
+    requests: Arc<Mutex<Vec<ModelCompletionRequest>>>,
+}
+
+impl CapturingProvider {
+    fn new(requests: Arc<Mutex<Vec<ModelCompletionRequest>>>) -> Self {
+        Self { requests }
+    }
+}
+
+#[async_trait]
+impl ModelProviderPort for CapturingProvider {
+    async fn complete(&self, request: ModelCompletionRequest) -> KernelResult<ModelCompletion> {
+        self.requests.lock().unwrap().push(request.clone());
+        Ok(ModelCompletion {
+            provider: "test".to_owned(),
+            model: "test-model".to_owned(),
+            directives: vec![ModelDirective::Message {
+                role: "assistant".to_owned(),
+                content: format!("ack: {}", request.objective),
+            }],
+            stop_reason: ModelStopReason::Completed,
+            usage: None,
+            final_answer: Some("ok".to_owned()),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct MutablePersonaIdentity {
+    agent_id: AgentId,
+    soul: SoulProfile,
+    generation: Arc<AtomicUsize>,
+}
+
+impl MutablePersonaIdentity {
+    fn new(generation: Arc<AtomicUsize>) -> Self {
+        Self {
+            agent_id: AgentId::default(),
+            soul: SoulProfile {
+                name: "Prompt Cache Tester".to_owned(),
+                mission: "Validate frozen system-prompt prefixes".to_owned(),
+                ..Default::default()
+            },
+            generation,
+        }
+    }
+}
+
+impl AgentIdentityProvider for MutablePersonaIdentity {
+    fn agent_id(&self) -> &AgentId {
+        &self.agent_id
+    }
+
+    fn soul_profile(&self) -> &SoulProfile {
+        &self.soul
+    }
+
+    fn persona_block(&self) -> String {
+        let generation = self.generation.load(Ordering::SeqCst);
+        format!(
+            "You are {} — {}.\nPersona generation: {generation}",
+            self.soul.name, self.soul.mission
+        )
+    }
+}
+
 fn unique_root(name: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -85,6 +157,13 @@ fn unique_root(name: &str) -> PathBuf {
 }
 
 fn build_runtime(root: PathBuf) -> Arc<KernelRuntime> {
+    build_runtime_with_provider(root, Arc::new(TestProvider))
+}
+
+fn build_runtime_with_provider(
+    root: PathBuf,
+    provider: Arc<dyn ModelProviderPort>,
+) -> Arc<KernelRuntime> {
     let event_store_backend = Arc::new(FileEventStore::new(root.join("kernel")));
     let journal = Arc::new(EventJournal::new(
         event_store_backend,
@@ -101,8 +180,6 @@ fn build_runtime(root: PathBuf) -> Arc<KernelRuntime> {
     let dispatcher = Arc::new(ToolDispatcher::new(registry, policy_engine, sandbox));
     let tool_harness: Arc<dyn ToolHarnessPort> = dispatcher;
 
-    let provider: Arc<dyn ModelProviderPort> = Arc::new(TestProvider);
-
     Arc::new(KernelRuntime::new(
         RuntimeConfig::new(root),
         event_store,
@@ -111,6 +188,18 @@ fn build_runtime(root: PathBuf) -> Arc<KernelRuntime> {
         approvals,
         policy_gate,
     ))
+}
+
+fn captured_system_prompt(
+    requests: &Arc<Mutex<Vec<ModelCompletionRequest>>>,
+    index: usize,
+) -> String {
+    requests
+        .lock()
+        .unwrap()
+        .get(index)
+        .and_then(|request| request.system_prompt.clone())
+        .expect("captured system prompt")
 }
 
 #[tokio::test]
@@ -536,6 +625,91 @@ async fn canonical_stream_branch_isolation() {
     assert!(
         !body.contains("feature-b branch work"),
         "main branch stream should not contain feature-b events, body: {body}"
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn canonical_freezes_system_prompt_prefix_per_session() {
+    let captured_requests = Arc::new(Mutex::new(Vec::new()));
+    let runtime = build_runtime_with_provider(
+        unique_root("arcand-frozen-prefix"),
+        Arc::new(CapturingProvider::new(captured_requests.clone())),
+    );
+    let persona_generation = Arc::new(AtomicUsize::new(1));
+    let identity: Arc<dyn AgentIdentityProvider> =
+        Arc::new(MutablePersonaIdentity::new(persona_generation.clone()));
+    let router = create_canonical_router_with_skills(
+        runtime,
+        test_provider_handle(),
+        test_provider_factory(),
+        None,
+        None,
+        Vec::new(),
+        Some(identity),
+        std::env::temp_dir(),
+        None,
+        None,
+        None,
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    let client = reqwest::Client::new();
+    let base = format!("http://{addr}");
+    let session_a = "frozen-prefix-a";
+    let session_b = "frozen-prefix-b";
+
+    let first_run = client
+        .post(format!("{base}/sessions/{session_a}/runs"))
+        .json(&json!({ "objective": "first turn" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first_run.status(), StatusCode::OK);
+
+    persona_generation.store(2, Ordering::SeqCst);
+
+    let second_run = client
+        .post(format!("{base}/sessions/{session_a}/runs"))
+        .json(&json!({ "objective": "second turn" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(second_run.status(), StatusCode::OK);
+
+    let third_run = client
+        .post(format!("{base}/sessions/{session_b}/runs"))
+        .json(&json!({ "objective": "new session turn" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(third_run.status(), StatusCode::OK);
+
+    let first_prompt = captured_system_prompt(&captured_requests, 0);
+    let second_prompt = captured_system_prompt(&captured_requests, 1);
+    let third_prompt = captured_system_prompt(&captured_requests, 2);
+
+    assert!(
+        first_prompt.contains("Persona generation: 1"),
+        "first session should capture generation 1, prompt: {first_prompt}"
+    );
+    assert_eq!(
+        first_prompt, second_prompt,
+        "same session should reuse the frozen prompt prefix"
+    );
+    assert!(
+        third_prompt.contains("Persona generation: 2"),
+        "new session should pick up the updated prefix, prompt: {third_prompt}"
+    );
+    assert_ne!(
+        second_prompt, third_prompt,
+        "new sessions should recompute the prompt prefix"
     );
 
     server.abort();

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -68,8 +68,9 @@ Streaming notes:
 - Role: canonical API router crate.
 - Status: active.
 - Exports: `canonical`, `mock`.
-- Integration tests: canonical API lifecycle, named session auto-create on run, canonical v6 stream replay path.
+- Integration tests: canonical API lifecycle, named session auto-create on run, canonical v6 stream replay path, frozen system-prompt prefix reuse within a session.
 - Session continuity: canonical `POST /sessions` and `POST /sessions/{session_id}/runs` persist `${runtime_root}/last_session` for CLI/TUI resume behavior.
+- Prompt caching: canonical runs freeze the base system-prompt prefix on first session use so mid-session persona/skill-catalog changes do not invalidate provider prompt caches; new sessions recompute the prefix.
 
 ### `arcan-aios-adapters`
 
@@ -192,9 +193,10 @@ Canonical host behavior validated by passing tests including:
 1. Canonical session API round-trip.
 2. Named-session run auto-creation behavior.
 3. Canonical stream replay framing and Vercel v6 envelope/header path.
-4. Arcan-Lago replay/bridge integration tests.
-5. Sandbox provider lifecycle (create/run/snapshot/destroy) across all backends.
-6. Session store tier-aware TTL expiration (anonymous/free/pro/enterprise).
+4. Frozen system-prompt prefix stays stable within a session and refreshes on new sessions.
+5. Arcan-Lago replay/bridge integration tests.
+6. Sandbox provider lifecycle (create/run/snapshot/destroy) across all backends.
+7. Session store tier-aware TTL expiration (anonymous/free/pro/enterprise).
 
 ---
 


### PR DESCRIPTION
## Summary
- freeze the base system prompt prefix on first session use in `arcand`
- keep dynamic per-turn suffixes like active skill prompts appended without invalidating the frozen prefix
- add an integration test that proves same-session prompt reuse and new-session refresh behavior
- fix the remaining workspace clippy blocker in `arcan` so repo validation passes cleanly

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p arcand canonical_freezes_system_prompt_prefix_per_session -- --nocapture`
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented session-based prompt caching to maintain system stability and consistency, preventing disruptions when personas or skill catalogs change during active sessions.

* **Tests**
  * Added integration tests to verify prompt consistency within sessions and appropriate updates across different sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->