### PR TITLE
feat(consciousness): core actor loop for event-driven sessions (BRO-455)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "autonomic-core",
  "axum 0.8.8",
  "chrono",
+ "futures-util",
  "http-body-util",
  "jsonwebtoken",
  "life-vigil",

--- a/crates/arcan-core/src/lib.rs
+++ b/crates/arcan-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod lifecycle;
 pub mod prompt;
 pub mod protocol;
 pub mod protocol_bridge;
+pub mod queue;
 pub mod runtime;
 pub mod state;
 

--- a/crates/arcan-core/src/queue.rs
+++ b/crates/arcan-core/src/queue.rs
@@ -130,7 +130,10 @@ impl MessageQueue {
 
     /// Enqueue a message. Returns error if queue is full.
     pub fn enqueue(&self, message: QueuedMessage) -> Result<(), QueueError> {
-        let mut inner = self.inner.lock().map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
         if inner.pending.len() >= self.config.max_queue_depth {
             return Err(QueueError::QueueFull {
                 depth: inner.pending.len(),
@@ -145,7 +148,10 @@ impl MessageQueue {
 
     /// Remove a specific queued message by ID.
     pub fn remove(&self, id: &str) -> Result<QueuedMessage, QueueError> {
-        let mut inner = self.inner.lock().map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
         let pos = inner
             .pending
             .iter()
@@ -156,7 +162,10 @@ impl MessageQueue {
 
     /// Get a snapshot of the current queue state.
     pub fn status(&self) -> Result<QueueStatus, QueueError> {
-        let inner = self.inner.lock().map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
         let oldest_age = inner
             .pending
             .front()
@@ -171,14 +180,20 @@ impl MessageQueue {
 
     /// Mark that an active run has started.
     pub fn set_active_run(&self, active: bool) -> Result<(), QueueError> {
-        let mut inner = self.inner.lock().map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
         inner.has_active_run = active;
         Ok(())
     }
 
     /// Whether there is an active run.
     pub fn has_active_run(&self) -> Result<bool, QueueError> {
-        let inner = self.inner.lock().map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
         Ok(inner.has_active_run)
     }
 
@@ -187,7 +202,10 @@ impl MessageQueue {
     /// Inspects the queue for `Interrupt` or `Steer` messages and returns
     /// the appropriate `SteeringAction`. Priority: interrupt > steer.
     pub fn check_preemption(&self) -> Result<SteeringAction, QueueError> {
-        let mut inner = self.inner.lock().map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
 
         // Priority 1: Interrupt messages — abort immediately
         if let Some(pos) = inner
@@ -219,11 +237,14 @@ impl MessageQueue {
     /// Returns messages ordered: followup first (same context), then collect (fresh runs).
     /// Collect messages within the coalesce window are batched together.
     pub fn drain_after_run(&self) -> Result<Vec<QueuedMessage>, QueueError> {
-        let mut inner = self.inner.lock().map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
         inner.has_active_run = false;
 
         if inner.pending.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         let mut followups = Vec::new();
@@ -247,7 +268,6 @@ impl MessageQueue {
             let (within_window, outside): (Vec<_>, Vec<_>) = collects
                 .into_iter()
                 .partition(|m| m.queued_at.is_some_and(|t| now.duration_since(t) <= window));
-            // Keep outside-window messages as individual items
             for msg in outside {
                 remaining.push_back(msg);
             }
@@ -256,17 +276,17 @@ impl MessageQueue {
 
         inner.pending = remaining;
 
-        // Return in priority order: followups first, then collects
         let mut result = followups;
         result.extend(collects);
         Ok(result)
     }
 
-    /// Check queue health for heartbeat integration (Phase 2.4).
-    ///
-    /// Returns warnings if queue depth exceeds threshold or messages are stale.
+    /// Check queue health for heartbeat integration.
     pub fn health_check(&self) -> Result<Vec<String>, QueueError> {
-        let inner = self.inner.lock().map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
         let mut warnings = Vec::new();
 
         let depth = inner.pending.len();
@@ -295,7 +315,10 @@ impl MessageQueue {
 
     /// Current queue depth.
     pub fn depth(&self) -> Result<usize, QueueError> {
-        let inner = self.inner.lock().map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|e| QueueError::LockPoisoned(e.to_string()))?;
         Ok(inner.pending.len())
     }
 
@@ -306,7 +329,7 @@ impl MessageQueue {
 }
 
 impl PreemptionCheck for MessageQueue {
-    fn check_preemption(&self) -> SteeringAction {
+    fn check_preemption(&self) -> Result<SteeringAction, QueueError> {
         self.check_preemption()
     }
 }
@@ -336,34 +359,36 @@ mod tests {
     #[test]
     fn collect_mode_queued_and_drained() {
         let queue = MessageQueue::new(QueueConfig::default());
-        queue.set_active_run(true);
+        queue.set_active_run(true).unwrap();
 
         queue
             .enqueue(make_msg("q1", SteeringMode::Collect, "do this later"))
             .unwrap();
 
-        assert_eq!(queue.depth(), 1);
-        assert!(queue.has_active_run());
+        assert_eq!(queue.depth().unwrap(), 1);
+        assert!(queue.has_active_run().unwrap());
 
-        // Preemption check should return Continue (collect doesn't preempt)
-        assert!(matches!(queue.check_preemption(), SteeringAction::Continue));
+        assert!(matches!(
+            queue.check_preemption().unwrap(),
+            SteeringAction::Continue
+        ));
 
-        let drained = queue.drain_after_run();
+        let drained = queue.drain_after_run().unwrap();
         assert_eq!(drained.len(), 1);
         assert_eq!(drained[0].id, "q1");
-        assert!(!queue.has_active_run());
+        assert!(!queue.has_active_run().unwrap());
     }
 
     #[test]
     fn steer_mode_preempts_at_tool_boundary() {
         let queue = MessageQueue::new(QueueConfig::default());
-        queue.set_active_run(true);
+        queue.set_active_run(true).unwrap();
 
         queue
             .enqueue(make_msg("q1", SteeringMode::Steer, "do this instead"))
             .unwrap();
 
-        match queue.check_preemption() {
+        match queue.check_preemption().unwrap() {
             SteeringAction::CompleteAndSwitch(msg) => {
                 assert_eq!(msg.id, "q1");
                 assert_eq!(msg.content, "do this instead");
@@ -371,14 +396,13 @@ mod tests {
             other => panic!("expected CompleteAndSwitch, got {other:?}"),
         }
 
-        // Queue should be empty after steer consumed
-        assert_eq!(queue.depth(), 0);
+        assert_eq!(queue.depth().unwrap(), 0);
     }
 
     #[test]
     fn followup_inherits_context_order() {
         let queue = MessageQueue::new(QueueConfig::default());
-        queue.set_active_run(true);
+        queue.set_active_run(true).unwrap();
 
         queue
             .enqueue(make_msg("c1", SteeringMode::Collect, "fresh run"))
@@ -387,8 +411,7 @@ mod tests {
             .enqueue(make_msg("f1", SteeringMode::Followup, "same context"))
             .unwrap();
 
-        let drained = queue.drain_after_run();
-        // Followup comes before Collect
+        let drained = queue.drain_after_run().unwrap();
         assert_eq!(drained.len(), 2);
         assert_eq!(drained[0].id, "f1");
         assert_eq!(drained[1].id, "c1");
@@ -397,13 +420,13 @@ mod tests {
     #[test]
     fn interrupt_aborts_at_tool_boundary() {
         let queue = MessageQueue::new(QueueConfig::default());
-        queue.set_active_run(true);
+        queue.set_active_run(true).unwrap();
 
         queue
             .enqueue(make_msg("i1", SteeringMode::Interrupt, "stop now"))
             .unwrap();
 
-        match queue.check_preemption() {
+        match queue.check_preemption().unwrap() {
             SteeringAction::Abort { reason } => {
                 assert!(reason.contains("i1"));
             }
@@ -436,17 +459,14 @@ mod tests {
 
     #[test]
     fn steer_timeout_falls_back_to_collect() {
-        // If no tool boundary occurs within timeout, steer messages
-        // are treated as collect messages when drained.
         let queue = MessageQueue::new(QueueConfig::default());
-        queue.set_active_run(true);
+        queue.set_active_run(true).unwrap();
 
         queue
             .enqueue(make_msg("s1", SteeringMode::Steer, "should steer"))
             .unwrap();
 
-        // Simulate: we never call check_preemption, run finishes naturally
-        let drained = queue.drain_after_run();
+        let drained = queue.drain_after_run().unwrap();
         assert_eq!(drained.len(), 1);
         assert_eq!(drained[0].id, "s1");
     }
@@ -454,13 +474,12 @@ mod tests {
     #[test]
     fn collect_messages_coalesced_within_window() {
         let config = QueueConfig {
-            collect_coalesce_window: Duration::from_secs(10), // large window
+            collect_coalesce_window: Duration::from_secs(10),
             ..Default::default()
         };
         let queue = MessageQueue::new(config);
-        queue.set_active_run(true);
+        queue.set_active_run(true).unwrap();
 
-        // All messages queued close together
         queue
             .enqueue(make_msg("c1", SteeringMode::Collect, "a"))
             .unwrap();
@@ -471,15 +490,14 @@ mod tests {
             .enqueue(make_msg("c3", SteeringMode::Collect, "c"))
             .unwrap();
 
-        let drained = queue.drain_after_run();
-        // All should be drained together
+        let drained = queue.drain_after_run().unwrap();
         assert_eq!(drained.len(), 3);
     }
 
     #[test]
     fn drain_order_interrupt_steer_followup_collect() {
         let queue = MessageQueue::new(QueueConfig::default());
-        queue.set_active_run(true);
+        queue.set_active_run(true).unwrap();
 
         queue
             .enqueue(make_msg("c1", SteeringMode::Collect, "collect"))
@@ -494,20 +512,17 @@ mod tests {
             .enqueue(make_msg("s1", SteeringMode::Steer, "steer"))
             .unwrap();
 
-        // Preemption should pick up interrupt first (highest priority)
-        match queue.check_preemption() {
+        match queue.check_preemption().unwrap() {
             SteeringAction::Abort { .. } => {}
             other => panic!("expected Abort from interrupt, got {other:?}"),
         }
 
-        // Next preemption check should pick steer
-        match queue.check_preemption() {
+        match queue.check_preemption().unwrap() {
             SteeringAction::CompleteAndSwitch(msg) => assert_eq!(msg.id, "s1"),
             other => panic!("expected CompleteAndSwitch from steer, got {other:?}"),
         }
 
-        // Drain remaining: followup before collect
-        let drained = queue.drain_after_run();
+        let drained = queue.drain_after_run().unwrap();
         assert_eq!(drained.len(), 2);
         assert_eq!(drained[0].id, "f1");
         assert_eq!(drained[1].id, "c1");
@@ -516,7 +531,10 @@ mod tests {
     #[test]
     fn preemption_returns_continue_on_empty_queue() {
         let queue = MessageQueue::new(QueueConfig::default());
-        assert!(matches!(queue.check_preemption(), SteeringAction::Continue));
+        assert!(matches!(
+            queue.check_preemption().unwrap(),
+            SteeringAction::Continue
+        ));
     }
 
     #[test]
@@ -531,21 +549,20 @@ mod tests {
 
         let removed = queue.remove("q1").unwrap();
         assert_eq!(removed.id, "q1");
-        assert_eq!(queue.depth(), 1);
+        assert_eq!(queue.depth().unwrap(), 1);
 
-        // Removing non-existent returns error
         assert!(queue.remove("q99").is_err());
     }
 
     #[test]
     fn status_snapshot() {
         let queue = MessageQueue::new(QueueConfig::default());
-        queue.set_active_run(true);
+        queue.set_active_run(true).unwrap();
         queue
             .enqueue(make_msg("q1", SteeringMode::Collect, "test"))
             .unwrap();
 
-        let status = queue.status();
+        let status = queue.status().unwrap();
         assert_eq!(status.depth, 1);
         assert!(status.has_active_run);
         assert_eq!(status.pending.len(), 1);
@@ -560,14 +577,13 @@ mod tests {
         };
         let queue = MessageQueue::new(config);
 
-        // Fill past half
         for i in 0..3 {
             queue
                 .enqueue(make_msg(&format!("q{i}"), SteeringMode::Collect, "x"))
                 .unwrap();
         }
 
-        let warnings = queue.health_check();
+        let warnings = queue.health_check().unwrap();
         assert!(
             warnings
                 .iter()
@@ -583,13 +599,13 @@ mod tests {
         queue
             .enqueue(make_msg("q1", SteeringMode::Collect, "shared"))
             .unwrap();
-        assert_eq!(queue2.depth(), 1);
+        assert_eq!(queue2.depth().unwrap(), 1);
     }
 
     #[test]
     fn multiple_followups_preserved_in_order() {
         let queue = MessageQueue::new(QueueConfig::default());
-        queue.set_active_run(true);
+        queue.set_active_run(true).unwrap();
 
         queue
             .enqueue(make_msg("f1", SteeringMode::Followup, "first"))
@@ -601,7 +617,7 @@ mod tests {
             .enqueue(make_msg("f3", SteeringMode::Followup, "third"))
             .unwrap();
 
-        let drained = queue.drain_after_run();
+        let drained = queue.drain_after_run().unwrap();
         assert_eq!(drained.len(), 3);
         assert_eq!(drained[0].id, "f1");
         assert_eq!(drained[1].id, "f2");
@@ -611,8 +627,8 @@ mod tests {
     #[test]
     fn drain_empty_queue_returns_empty() {
         let queue = MessageQueue::new(QueueConfig::default());
-        queue.set_active_run(true);
-        let drained = queue.drain_after_run();
+        queue.set_active_run(true).unwrap();
+        let drained = queue.drain_after_run().unwrap();
         assert!(drained.is_empty());
     }
 }

--- a/crates/arcan-tui/src/app.rs
+++ b/crates/arcan-tui/src/app.rs
@@ -855,16 +855,13 @@ impl App {
         }
 
         // Autonomic details
-        match self.client.get_autonomic().await {
-            Ok(info) => {
-                lines.push(format!(
-                    "  Autonomic: {} — quality {:.2}, pressure {:.0}%",
-                    info.ruling,
-                    info.quality_score,
-                    info.pressure * 100.0,
-                ));
-            }
-            Err(_) => {} // Already covered by context ruling
+        if let Ok(info) = self.client.get_autonomic().await {
+            lines.push(format!(
+                "  Autonomic: {} — quality {:.2}, pressure {:.0}%",
+                info.ruling,
+                info.quality_score,
+                info.pressure * 100.0,
+            ));
         }
 
         // Cost

--- a/crates/arcand/Cargo.toml
+++ b/crates/arcand/Cargo.toml
@@ -38,6 +38,7 @@ jsonwebtoken.workspace = true
 nous-api.workspace = true
 nous-core.workspace = true
 life-vigil.workspace = true
+futures-util.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/arcand/src/canonical.rs
+++ b/crates/arcand/src/canonical.rs
@@ -230,6 +230,10 @@ struct CanonicalState {
     /// Refreshed at most every 60 seconds to avoid running git on every request.
     /// BRO-374: Daemon injects git context into system prompt.
     cached_git_context: Arc<Mutex<Option<(Instant, String)>>>,
+    /// Consciousness registry for event-driven session actors (BRO-455).
+    /// When `ARCAN_CONSCIOUSNESS=true`, run_session pushes events to actors
+    /// instead of blocking on the tick loop.
+    consciousness_registry: Option<Arc<crate::consciousness::ConsciousnessRegistry>>,
 }
 
 /// Daemon-level Autonomic context regulation state.
@@ -692,6 +696,14 @@ pub fn create_canonical_router_with_skills(
         bare,
         autonomic: Arc::new(Mutex::new(AutonomicDaemonState::new(bare))),
         cached_git_context: Arc::new(Mutex::new(None)),
+        consciousness_registry: if crate::consciousness::is_consciousness_enabled() {
+            tracing::info!("Consciousness mode ENABLED (BRO-455)");
+            Some(Arc::new(crate::consciousness::ConsciousnessRegistry::new(
+                crate::consciousness::ConsciousnessConfig::default(),
+            )))
+        } else {
+            None
+        },
     };
 
     let auth_config = Arc::new(AuthConfig::from_env());
@@ -1577,6 +1589,72 @@ async fn run_session(
         tool_filter = ?combined_allowed_tools.as_ref().map(Vec::len),
         "running agent tick with identity"
     );
+
+    // ─── Consciousness dispatch (BRO-455) ────────────────────────────
+    // When ARCAN_CONSCIOUSNESS=true, push the message to the session's
+    // consciousness actor instead of blocking on the tick loop.
+    if let Some(ref registry) = state.consciousness_registry {
+        let handle =
+            registry.get_or_create(session_id.as_str(), branch.clone(), state.runtime.clone());
+
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        let send_result = handle
+            .send(crate::consciousness::ConsciousnessEvent::UserMessage(
+                Box::new(crate::consciousness::UserMessageEvent {
+                    objective: objective.clone(),
+                    branch: branch.clone(),
+                    steering: aios_protocol::SteeringMode::Collect,
+                    ack: Some(ack_tx),
+                    run_context: crate::consciousness::RunContext {
+                        system_prompt: system_prompt.clone(),
+                        allowed_tools: combined_allowed_tools.clone(),
+                        proposed_tool: proposed_tool.clone(),
+                    },
+                }),
+            ))
+            .await;
+
+        if send_result.is_err() {
+            return Err(internal_error(format!(
+                "consciousness actor for session {} is not running",
+                session_id
+            )));
+        }
+
+        // Wait for acknowledgment (fast — actor responds immediately).
+        match tokio::time::timeout(Duration::from_secs(5), ack_rx).await {
+            Ok(Ok(crate::consciousness::ConsciousnessAck::Accepted { queued })) => {
+                tracing::info!(
+                    session = %session_id,
+                    queued,
+                    "consciousness accepted message"
+                );
+                return Ok(Json(RunResponse {
+                    session_id,
+                    mode: OperatingMode::Execute,
+                    state: AgentStateVector::default(),
+                    events_emitted: 0,
+                    last_sequence: 0,
+                }));
+            }
+            Ok(Ok(crate::consciousness::ConsciousnessAck::Rejected { reason })) => {
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({ "error": "consciousness_rejected", "reason": reason })),
+                ));
+            }
+            Ok(Err(_)) => {
+                return Err(internal_error("consciousness actor dropped ack channel"));
+            }
+            Err(_) => {
+                return Err((
+                    StatusCode::GATEWAY_TIMEOUT,
+                    Json(json!({ "error": "consciousness_timeout" })),
+                ));
+            }
+        }
+    }
+    // ─── End consciousness dispatch ──────────────────────────────────
 
     // BRO-217: For anonymous sessions, mark as ephemeral so that MemoryProposed /
     // MemoryCommitted events are discarded instead of persisted to Lago.

--- a/crates/arcand/src/consciousness.rs
+++ b/crates/arcand/src/consciousness.rs
@@ -1,0 +1,648 @@
+//! Session consciousness — event-driven actor loop for concurrent message handling.
+//!
+//! Each session gets a long-lived `tokio::spawn` task (the "consciousness actor")
+//! that owns a `tokio::select!` event loop. HTTP handlers become thin event-pushers
+//! that return 202 Accepted. All results flow via the existing SSE streaming.
+//!
+//! Feature-flagged behind `ARCAN_CONSCIOUSNESS=true`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use aios_protocol::{BranchId, EventKind, OperatingMode, SessionId, SteeringMode};
+use aios_runtime::{KernelRuntime, TickInput};
+use arcan_core::queue::{MessageQueue, QueueConfig, QueuedMessage, SteeringAction};
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tracing::{Instrument, debug, error, info, warn};
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+/// Configuration for the consciousness actor.
+#[derive(Debug, Clone)]
+pub struct ConsciousnessConfig {
+    /// Channel buffer size for incoming events.
+    pub channel_buffer: usize,
+    /// Heartbeat interval (default: 30s).
+    pub heartbeat_interval: Duration,
+    /// Idle check interval (default: 60s).
+    pub idle_check_interval: Duration,
+    /// Max agent iterations per run (default: 10).
+    pub max_agent_iterations: u32,
+    /// Time before transitioning from Idle to Sleeping (default: 5min).
+    pub idle_to_sleep: Duration,
+}
+
+impl Default for ConsciousnessConfig {
+    fn default() -> Self {
+        Self {
+            channel_buffer: 32,
+            heartbeat_interval: Duration::from_secs(30),
+            idle_check_interval: Duration::from_secs(60),
+            max_agent_iterations: 10,
+            idle_to_sleep: Duration::from_secs(300),
+        }
+    }
+}
+
+// ─── Event types ────────────────────────────────────────────────────────────
+
+/// Unified stimulus enum — every input to the consciousness actor.
+#[derive(Debug)]
+pub enum ConsciousnessEvent {
+    /// User message from HTTP POST /runs or /messages.
+    UserMessage(Box<UserMessageEvent>),
+    /// Timer tick from internal intervals.
+    TimerTick { tick_type: TimerTickType },
+    /// Graceful shutdown request.
+    Shutdown,
+}
+
+/// Payload for a user message event (boxed to keep enum small).
+#[derive(Debug)]
+pub struct UserMessageEvent {
+    pub objective: String,
+    pub branch: BranchId,
+    pub steering: SteeringMode,
+    /// Acknowledgment channel: actor sends back once queued/started.
+    pub ack: Option<oneshot::Sender<ConsciousnessAck>>,
+    /// Pre-built run context (system prompt, allowed tools, proposed tool).
+    pub run_context: RunContext,
+}
+
+/// Timer tick types for the consciousness heartbeat.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimerTickType {
+    Heartbeat,
+    IdleCheck,
+}
+
+/// Pre-built context for an agent run (passed from HTTP handler).
+#[derive(Debug, Clone, Default)]
+pub struct RunContext {
+    pub system_prompt: Option<String>,
+    pub allowed_tools: Option<Vec<String>>,
+    pub proposed_tool: Option<aios_protocol::ToolCall>,
+}
+
+/// Acknowledgment sent back to the HTTP handler after event is received.
+#[derive(Debug)]
+pub enum ConsciousnessAck {
+    /// Event was accepted; run started or queued.
+    Accepted { queued: bool },
+    /// Event was rejected (e.g., shutting down).
+    Rejected { reason: String },
+}
+
+// ─── Actor state ────────────────────────────────────────────────────────────
+
+/// Operating mode of the consciousness actor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsciousnessMode {
+    /// Actively running an agent cycle.
+    Active,
+    /// No active work — ready for new messages.
+    Idle,
+    /// Low-power mode after extended inactivity.
+    Sleeping,
+    /// Gracefully shutting down.
+    ShuttingDown,
+}
+
+/// Per-session mutable state owned by the consciousness actor.
+struct ConsciousnessState {
+    session_id: SessionId,
+    branch: BranchId,
+    mode: ConsciousnessMode,
+    queue: MessageQueue,
+    last_activity: Instant,
+}
+
+impl ConsciousnessState {
+    fn new(session_id: SessionId, branch: BranchId) -> Self {
+        Self {
+            session_id,
+            branch,
+            mode: ConsciousnessMode::Idle,
+            queue: MessageQueue::new(QueueConfig::default()),
+            last_activity: Instant::now(),
+        }
+    }
+}
+
+// ─── Actor ──────────────────────────────────────────────────────────────────
+
+/// The consciousness actor — a long-lived tokio task per session.
+pub struct SessionConsciousness {
+    rx: mpsc::Receiver<ConsciousnessEvent>,
+    state: ConsciousnessState,
+    runtime: Arc<KernelRuntime>,
+    config: ConsciousnessConfig,
+}
+
+impl SessionConsciousness {
+    /// Spawn a new consciousness actor for the given session.
+    ///
+    /// Returns the `JoinHandle` and a `Sender` for pushing events.
+    pub fn spawn(
+        session_id: SessionId,
+        branch: BranchId,
+        runtime: Arc<KernelRuntime>,
+        config: ConsciousnessConfig,
+    ) -> (JoinHandle<()>, mpsc::Sender<ConsciousnessEvent>) {
+        let (tx, rx) = mpsc::channel(config.channel_buffer);
+        let span = tracing::info_span!("consciousness", session = %session_id);
+        let actor = Self {
+            rx,
+            state: ConsciousnessState::new(session_id, branch),
+            runtime,
+            config,
+        };
+        let handle = tokio::spawn(actor.run().instrument(span));
+        (handle, tx)
+    }
+
+    /// Main event loop — runs until Shutdown or channel closes.
+    async fn run(mut self) {
+        info!(session = %self.state.session_id, "consciousness actor started");
+
+        let mut heartbeat = tokio::time::interval(self.config.heartbeat_interval);
+        let mut idle_check = tokio::time::interval(self.config.idle_check_interval);
+        // Skip the immediate first tick (fires at interval creation).
+        heartbeat.tick().await;
+        idle_check.tick().await;
+
+        loop {
+            let event = tokio::select! {
+                biased;
+
+                // Prioritize incoming events over timers.
+                msg = self.rx.recv() => match msg {
+                    Some(e) => e,
+                    None => {
+                        info!(session = %self.state.session_id, "channel closed, shutting down");
+                        break;
+                    }
+                },
+
+                _ = heartbeat.tick() => ConsciousnessEvent::TimerTick {
+                    tick_type: TimerTickType::Heartbeat,
+                },
+
+                _ = idle_check.tick() => ConsciousnessEvent::TimerTick {
+                    tick_type: TimerTickType::IdleCheck,
+                },
+            };
+
+            match event {
+                ConsciousnessEvent::Shutdown => {
+                    info!(session = %self.state.session_id, "shutdown requested");
+                    self.state.mode = ConsciousnessMode::ShuttingDown;
+                    break;
+                }
+                ConsciousnessEvent::UserMessage(msg) => {
+                    self.handle_user_message(
+                        msg.objective,
+                        msg.branch,
+                        msg.steering,
+                        msg.ack,
+                        msg.run_context,
+                    )
+                    .await;
+                }
+                ConsciousnessEvent::TimerTick { tick_type } => {
+                    self.handle_timer_tick(tick_type).await;
+                }
+            }
+        }
+
+        // Emit final heartbeat before stopping.
+        let _ = self
+            .runtime
+            .record_external_event(
+                &self.state.session_id,
+                EventKind::Heartbeat {
+                    summary: "consciousness-tick".to_string(),
+                    checkpoint_id: None,
+                },
+            )
+            .await;
+
+        info!(session = %self.state.session_id, "consciousness actor stopped");
+    }
+
+    /// Handle an incoming user message.
+    ///
+    /// If idle/sleeping, start a new agent cycle immediately.
+    /// If active, queue the message with the specified steering mode.
+    async fn handle_user_message(
+        &mut self,
+        objective: String,
+        branch: BranchId,
+        steering: SteeringMode,
+        ack: Option<oneshot::Sender<ConsciousnessAck>>,
+        run_context: RunContext,
+    ) {
+        self.state.last_activity = Instant::now();
+        self.state.branch = branch.clone();
+
+        match self.state.mode {
+            ConsciousnessMode::Idle | ConsciousnessMode::Sleeping => {
+                // Start a new run immediately.
+                if let Some(ack) = ack {
+                    let _ = ack.send(ConsciousnessAck::Accepted { queued: false });
+                }
+                self.state.mode = ConsciousnessMode::Active;
+                self.run_agent_cycle(objective, branch, run_context).await;
+                self.drain_queue_after_run().await;
+            }
+            ConsciousnessMode::Active => {
+                // Queue the message for later processing.
+                let msg_id = uuid::Uuid::new_v4().to_string();
+                let queued = QueuedMessage {
+                    id: msg_id.clone(),
+                    mode: steering,
+                    content: objective,
+                    queued_at: None, // set by enqueue()
+                };
+                match self.state.queue.enqueue(queued) {
+                    Ok(()) => {
+                        info!(msg_id, "message queued during active run");
+                        let _ = self
+                            .runtime
+                            .record_external_event(
+                                &self.state.session_id,
+                                EventKind::Queued {
+                                    queue_id: msg_id,
+                                    mode: steering,
+                                    message: String::new(),
+                                },
+                            )
+                            .await;
+                        if let Some(ack) = ack {
+                            let _ = ack.send(ConsciousnessAck::Accepted { queued: true });
+                        }
+                    }
+                    Err(err) => {
+                        warn!(%err, "failed to queue message");
+                        if let Some(ack) = ack {
+                            let _ = ack.send(ConsciousnessAck::Rejected {
+                                reason: err.to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+            ConsciousnessMode::ShuttingDown => {
+                if let Some(ack) = ack {
+                    let _ = ack.send(ConsciousnessAck::Rejected {
+                        reason: "session is shutting down".to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Run the agent loop: tick repeatedly until end_turn or max iterations.
+    ///
+    /// Equivalent to the blocking loop in `canonical.rs` run_session handler.
+    async fn run_agent_cycle(
+        &mut self,
+        objective: String,
+        branch: BranchId,
+        run_context: RunContext,
+    ) {
+        let run_id = uuid::Uuid::new_v4().to_string();
+        self.state.queue.set_active_run(true).ok();
+
+        debug!(run_id, objective = %objective, "starting agent cycle");
+
+        let agent_span = life_vigil::spans::agent_span(self.state.session_id.as_str(), "arcan");
+
+        // First tick with the actual objective.
+        let mut tick_result = self
+            .runtime
+            .tick_on_branch(
+                &self.state.session_id,
+                &branch,
+                TickInput {
+                    objective,
+                    proposed_tool: run_context.proposed_tool,
+                    system_prompt: run_context.system_prompt.clone(),
+                    allowed_tools: run_context.allowed_tools.clone(),
+                },
+            )
+            .instrument(agent_span.clone())
+            .await;
+
+        // Continue ticking while mode=Execute (tools ran, need continuation).
+        for iteration in 1..self.config.max_agent_iterations {
+            match &tick_result {
+                Ok(tick) if tick.mode == OperatingMode::Execute => {
+                    // Check preemption at tool boundary.
+                    match self.state.queue.check_preemption() {
+                        Ok(SteeringAction::Abort { reason }) => {
+                            warn!(iteration, %reason, "run aborted by interrupt");
+                            let _ = self
+                                .runtime
+                                .record_external_event(
+                                    &self.state.session_id,
+                                    EventKind::Steered {
+                                        queue_id: run_id.clone(),
+                                        preempted_at: format!("iteration:{iteration}"),
+                                    },
+                                )
+                                .await;
+                            break;
+                        }
+                        Ok(SteeringAction::CompleteAndSwitch(msg)) => {
+                            info!(
+                                iteration,
+                                msg_id = %msg.id,
+                                "steering: switch after current iteration"
+                            );
+                            let _ = self
+                                .runtime
+                                .record_external_event(
+                                    &self.state.session_id,
+                                    EventKind::Steered {
+                                        queue_id: msg.id.clone(),
+                                        preempted_at: format!("iteration:{iteration}"),
+                                    },
+                                )
+                                .await;
+                            // Re-queue as followup for processing after drain.
+                            let requeue = QueuedMessage {
+                                id: msg.id,
+                                mode: SteeringMode::Followup,
+                                content: msg.content,
+                                queued_at: None,
+                            };
+                            self.state.queue.enqueue(requeue).ok();
+                            break;
+                        }
+                        Ok(SteeringAction::InjectMessage(_) | SteeringAction::Continue) => {}
+                        Err(err) => {
+                            warn!(%err, "preemption check failed, continuing");
+                        }
+                    }
+
+                    debug!(iteration, "agent loop: continuing after tool execution");
+                    tick_result = self
+                        .runtime
+                        .tick_on_branch(
+                            &self.state.session_id,
+                            &branch,
+                            TickInput {
+                                objective: String::new(),
+                                proposed_tool: None,
+                                system_prompt: run_context.system_prompt.clone(),
+                                allowed_tools: run_context.allowed_tools.clone(),
+                            },
+                        )
+                        .instrument(agent_span.clone())
+                        .await;
+                }
+                _ => break,
+            }
+        }
+
+        self.state.queue.set_active_run(false).ok();
+
+        match &tick_result {
+            Ok(tick) => {
+                debug!(mode = ?tick.mode, events = tick.events_emitted, "agent cycle completed");
+            }
+            Err(err) => {
+                error!(%err, "agent cycle failed");
+            }
+        }
+
+        self.state.mode = ConsciousnessMode::Idle;
+        self.state.last_activity = Instant::now();
+    }
+
+    /// Process queued messages after a run completes.
+    async fn drain_queue_after_run(&mut self) {
+        let drained: Vec<QueuedMessage> = match self.state.queue.drain_after_run() {
+            Ok(msgs) => msgs,
+            Err(err) => {
+                warn!(%err, "failed to drain queue");
+                return;
+            }
+        };
+
+        if drained.is_empty() {
+            return;
+        }
+
+        let count = drained.len();
+        info!(count, "draining queued messages after run");
+
+        let _ = self
+            .runtime
+            .record_external_event(
+                &self.state.session_id,
+                EventKind::QueueDrained {
+                    queue_id: "post-run-drain".to_string(),
+                    processed: count,
+                },
+            )
+            .await;
+
+        for msg in drained {
+            self.state.mode = ConsciousnessMode::Active;
+            self.run_agent_cycle(
+                msg.content,
+                self.state.branch.clone(),
+                RunContext::default(),
+            )
+            .await;
+        }
+    }
+
+    /// Handle timer ticks (heartbeat, idle check).
+    async fn handle_timer_tick(&mut self, tick_type: TimerTickType) {
+        match tick_type {
+            TimerTickType::Heartbeat => {
+                let _ = self
+                    .runtime
+                    .record_external_event(
+                        &self.state.session_id,
+                        EventKind::Heartbeat {
+                            summary: "consciousness-tick".to_string(),
+                            checkpoint_id: None,
+                        },
+                    )
+                    .await;
+
+                if let Ok(warnings) = self.state.queue.health_check() {
+                    for w in &warnings {
+                        warn!(session = %self.state.session_id, "{w}");
+                    }
+                }
+            }
+            TimerTickType::IdleCheck => {
+                if self.state.mode == ConsciousnessMode::Idle
+                    && self.state.last_activity.elapsed() > self.config.idle_to_sleep
+                {
+                    info!(
+                        session = %self.state.session_id,
+                        idle_secs = self.state.last_activity.elapsed().as_secs(),
+                        "transitioning to sleeping mode"
+                    );
+                    self.state.mode = ConsciousnessMode::Sleeping;
+                }
+            }
+        }
+    }
+}
+
+// ─── Handle ─────────────────────────────────────────────────────────────────
+
+/// Handle for communicating with a consciousness actor.
+#[derive(Clone)]
+pub struct ConsciousnessHandle {
+    /// Sender for pushing events to the actor.
+    pub tx: mpsc::Sender<ConsciousnessEvent>,
+    join: Arc<Mutex<Option<JoinHandle<()>>>>,
+}
+
+impl ConsciousnessHandle {
+    fn new(tx: mpsc::Sender<ConsciousnessEvent>, join: JoinHandle<()>) -> Self {
+        Self {
+            tx,
+            join: Arc::new(Mutex::new(Some(join))),
+        }
+    }
+
+    /// Check if the actor task is still running.
+    pub fn is_alive(&self) -> bool {
+        self.join
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .is_some_and(|h| !h.is_finished())
+    }
+
+    /// Send an event to the consciousness actor.
+    pub async fn send(
+        &self,
+        event: ConsciousnessEvent,
+    ) -> Result<(), mpsc::error::SendError<ConsciousnessEvent>> {
+        self.tx.send(event).await
+    }
+
+    /// Send a shutdown event and wait for the actor to stop.
+    pub async fn shutdown(self) {
+        let _ = self.tx.send(ConsciousnessEvent::Shutdown).await;
+        let join = self
+            .join
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(handle) = join {
+            let _ = tokio::time::timeout(Duration::from_secs(10), handle).await;
+        }
+    }
+}
+
+// ─── Registry ───────────────────────────────────────────────────────────────
+
+/// Registry mapping session IDs to consciousness actors.
+///
+/// Thread-safe: accessed from HTTP handlers (multiple threads) and
+/// from the actors themselves. Lock is never held across `.await`.
+pub struct ConsciousnessRegistry {
+    sessions: Mutex<HashMap<String, ConsciousnessHandle>>,
+    config: ConsciousnessConfig,
+}
+
+impl ConsciousnessRegistry {
+    pub fn new(config: ConsciousnessConfig) -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+            config,
+        }
+    }
+
+    /// Get an existing handle or create a new consciousness actor.
+    pub fn get_or_create(
+        &self,
+        session_id: &str,
+        branch: BranchId,
+        runtime: Arc<KernelRuntime>,
+    ) -> ConsciousnessHandle {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Return existing if alive.
+        if let Some(handle) = sessions.get(session_id) {
+            if handle.is_alive() {
+                return handle.clone();
+            }
+            sessions.remove(session_id);
+        }
+
+        // Spawn new actor.
+        let (join, tx) = SessionConsciousness::spawn(
+            SessionId::from_string(session_id.to_string()),
+            branch,
+            runtime,
+            self.config.clone(),
+        );
+        let handle = ConsciousnessHandle::new(tx, join);
+        sessions.insert(session_id.to_string(), handle.clone());
+
+        info!(session_id, "consciousness actor created");
+        handle
+    }
+
+    /// Get an existing handle (returns None if no actor for this session).
+    pub fn get(&self, session_id: &str) -> Option<ConsciousnessHandle> {
+        let sessions = self
+            .sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        sessions.get(session_id).filter(|h| h.is_alive()).cloned()
+    }
+
+    /// Number of active sessions.
+    pub fn session_count(&self) -> usize {
+        let sessions = self
+            .sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        sessions.values().filter(|h| h.is_alive()).count()
+    }
+
+    /// Shut down all consciousness actors gracefully.
+    pub async fn shutdown_all(&self) {
+        let handles: Vec<ConsciousnessHandle> = {
+            let mut sessions = self
+                .sessions
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            sessions.drain().map(|(_, h)| h).collect()
+        };
+
+        info!(
+            count = handles.len(),
+            "shutting down all consciousness actors"
+        );
+
+        let futures: Vec<_> = handles
+            .into_iter()
+            .map(ConsciousnessHandle::shutdown)
+            .collect();
+        futures_util::future::join_all(futures).await;
+    }
+}
+
+/// Check whether consciousness mode is enabled via env var.
+pub fn is_consciousness_enabled() -> bool {
+    std::env::var("ARCAN_CONSCIOUSNESS").is_ok_and(|v| v == "true" || v == "1")
+}

--- a/crates/arcand/src/lib.rs
+++ b/crates/arcand/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod canonical;
+pub mod consciousness;
 pub mod mcp_registry;
 pub mod mock;
 pub mod rate_limit;

--- a/crates/arcand/tests/consciousness_test.rs
+++ b/crates/arcand/tests/consciousness_test.rs
@@ -1,0 +1,204 @@
+//! Integration tests for the consciousness actor loop (BRO-455).
+//!
+//! These tests use a real `KernelRuntime` with mock ports to validate
+//! the consciousness actor's event loop, queuing, and mode transitions.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use aios_events::{EventJournal, EventStreamHub, FileEventStore};
+use aios_policy::{ApprovalQueue, SessionPolicyEngine};
+use aios_protocol::{
+    ApprovalPort, EventStorePort, KernelResult, ModelCompletion, ModelCompletionRequest,
+    ModelDirective, ModelProviderPort, ModelStopReason, PolicyGatePort, PolicySet, SteeringMode,
+    ToolHarnessPort,
+};
+use aios_runtime::{KernelRuntime, RuntimeConfig};
+use aios_sandbox::LocalSandboxRunner;
+use aios_tools::{ToolDispatcher, ToolRegistry};
+use arcand::consciousness::{
+    ConsciousnessAck, ConsciousnessConfig, ConsciousnessEvent, ConsciousnessRegistry, RunContext,
+    SessionConsciousness, UserMessageEvent,
+};
+use async_trait::async_trait;
+
+use aios_protocol::{BranchId, SessionId};
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Default)]
+struct TestProvider;
+
+#[async_trait]
+impl ModelProviderPort for TestProvider {
+    async fn complete(&self, request: ModelCompletionRequest) -> KernelResult<ModelCompletion> {
+        Ok(ModelCompletion {
+            provider: "test".to_owned(),
+            model: "test-model".to_owned(),
+            directives: vec![ModelDirective::Message {
+                role: "assistant".to_owned(),
+                content: format!("ack: {}", request.objective),
+            }],
+            stop_reason: ModelStopReason::Completed,
+            usage: None,
+            final_answer: Some("ok".to_owned()),
+        })
+    }
+}
+
+fn unique_root(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!("{name}-{nanos}"))
+}
+
+fn build_runtime(root: PathBuf) -> Arc<KernelRuntime> {
+    let event_store_backend = Arc::new(FileEventStore::new(root.join("kernel")));
+    let journal = Arc::new(EventJournal::new(
+        event_store_backend,
+        EventStreamHub::new(1024),
+    ));
+    let event_store: Arc<dyn EventStorePort> = journal;
+
+    let policy_engine = Arc::new(SessionPolicyEngine::new(PolicySet::default()));
+    let policy_gate: Arc<dyn PolicyGatePort> = policy_engine.clone();
+    let approvals: Arc<dyn ApprovalPort> = Arc::new(ApprovalQueue::default());
+
+    let registry = Arc::new(ToolRegistry::with_core_tools());
+    let sandbox = Arc::new(LocalSandboxRunner::new(vec!["echo".to_owned()]));
+    let dispatcher = Arc::new(ToolDispatcher::new(registry, policy_engine, sandbox));
+    let tool_harness: Arc<dyn ToolHarnessPort> = dispatcher;
+
+    Arc::new(KernelRuntime::new(
+        RuntimeConfig::new(root),
+        event_store,
+        Arc::new(TestProvider),
+        tool_harness,
+        approvals,
+        policy_gate,
+    ))
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn actor_shuts_down_cleanly() {
+    let runtime = build_runtime(unique_root("consciousness-shutdown"));
+    let session_id = SessionId::from_string("test-shutdown".to_string());
+    let branch = BranchId::main();
+
+    let (handle, tx) =
+        SessionConsciousness::spawn(session_id, branch, runtime, ConsciousnessConfig::default());
+
+    tx.send(ConsciousnessEvent::Shutdown).await.unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    assert!(result.is_ok(), "actor should shut down within 5s");
+}
+
+#[tokio::test]
+async fn actor_accepts_message_when_idle() {
+    let runtime = build_runtime(unique_root("consciousness-idle-msg"));
+    let session_id = SessionId::from_string("test-idle-msg".to_string());
+
+    runtime
+        .create_session_with_id(
+            session_id.clone(),
+            "test",
+            PolicySet::default(),
+            aios_protocol::ModelRouting::default(),
+        )
+        .await
+        .unwrap();
+
+    let (handle, tx) = SessionConsciousness::spawn(
+        session_id,
+        BranchId::main(),
+        runtime,
+        ConsciousnessConfig {
+            max_agent_iterations: 1,
+            ..Default::default()
+        },
+    );
+
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+    tx.send(ConsciousnessEvent::UserMessage(Box::new(
+        UserMessageEvent {
+            objective: "Hello consciousness".to_string(),
+            branch: BranchId::main(),
+            steering: SteeringMode::Collect,
+            ack: Some(ack_tx),
+            run_context: RunContext::default(),
+        },
+    )))
+    .await
+    .unwrap();
+
+    let ack = tokio::time::timeout(Duration::from_secs(10), ack_rx)
+        .await
+        .expect("should get ack within 10s")
+        .expect("ack channel should not be dropped");
+
+    match ack {
+        ConsciousnessAck::Accepted { queued } => {
+            assert!(!queued, "should start immediately when idle");
+        }
+        ConsciousnessAck::Rejected { reason } => {
+            panic!("unexpected rejection: {reason}");
+        }
+    }
+
+    tx.send(ConsciousnessEvent::Shutdown).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+}
+
+#[tokio::test]
+async fn registry_creates_and_retrieves_handle() {
+    let runtime = build_runtime(unique_root("consciousness-registry"));
+    let registry = ConsciousnessRegistry::new(ConsciousnessConfig::default());
+
+    let handle = registry.get_or_create("test-registry", BranchId::main(), runtime.clone());
+    assert!(handle.is_alive());
+
+    let handle2 = registry.get_or_create("test-registry", BranchId::main(), runtime);
+    assert!(handle2.is_alive());
+
+    assert_eq!(registry.session_count(), 1);
+
+    registry.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn registry_shutdown_all_stops_actors() {
+    let runtime = build_runtime(unique_root("consciousness-shutdown-all"));
+    let registry = ConsciousnessRegistry::new(ConsciousnessConfig::default());
+
+    registry.get_or_create("s1", BranchId::main(), runtime.clone());
+    registry.get_or_create("s2", BranchId::main(), runtime);
+
+    assert_eq!(registry.session_count(), 2);
+
+    registry.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn channel_close_stops_actor() {
+    let runtime = build_runtime(unique_root("consciousness-channel-close"));
+    let session_id = SessionId::from_string("test-channel-close".to_string());
+
+    let (handle, tx) = SessionConsciousness::spawn(
+        session_id,
+        BranchId::main(),
+        runtime,
+        ConsciousnessConfig::default(),
+    );
+
+    // Drop the sender — actor should detect channel close and exit.
+    drop(tx);
+
+    let result = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    assert!(result.is_ok(), "actor should stop when channel closes");
+}

--- a/docs/superpowers/plans/2026-04-04-consciousness-actor-loop.md
+++ b/docs/superpowers/plans/2026-04-04-consciousness-actor-loop.md
@@ -1,0 +1,1311 @@
+# BRO-455: Core Consciousness Actor Loop — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the blocking request-response `run_session` handler with a long-lived per-session consciousness actor that owns a `tokio::select!` event loop, enabling concurrent message handling, queuing, and preemption.
+
+**Architecture:** Each session gets a `SessionConsciousness` actor spawned as a `tokio::spawn` task. HTTP handlers become thin event-pushers that send `ConsciousnessEvent` variants via `mpsc::Sender` and return immediately. The actor runs the existing `tick_on_branch` loop internally, checking preemption at iteration boundaries via the existing `MessageQueue` from `arcan-core/queue.rs`. Feature-flagged behind `ARCAN_CONSCIOUSNESS=true`.
+
+**Tech Stack:** Rust 2024 Edition, tokio (mpsc, select!, spawn, Interval), arcan-core MessageQueue, aios-runtime KernelRuntime, aios-protocol EventKind
+
+---
+
+## Dependency Chain
+
+```
+aios-protocol (EventKind, SteeringMode, OperatingMode) — READ ONLY
+  ↓
+aios-runtime (KernelRuntime, TickInput, TickOutput) — READ ONLY
+  ↓
+arcan-core (MessageQueue, QueueConfig, SwappableProviderHandle, ProviderFactory) — READ ONLY
+  ↓
+arcand (consciousness.rs — NEW, canonical.rs — MODIFY, lib.rs — MODIFY)
+```
+
+No upstream changes needed. All work is in the `arcand` crate.
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `crates/arcand/src/consciousness.rs` | CREATE | All consciousness types + actor + registry |
+| `crates/arcand/src/lib.rs` | MODIFY | Add `pub mod consciousness;` |
+| `crates/arcand/src/canonical.rs` | MODIFY | Add `consciousness_registry` to `CanonicalState`, modify `run_session` |
+| `crates/arcand/Cargo.toml` | MODIFY | No new deps needed (tokio + std::sync::Mutex already available) |
+
+**Design note:** The existing codebase uses `std::sync::Mutex` throughout `CanonicalState` (lines 222-232 of canonical.rs). The registry lock is never held across `.await` points, so `std::sync::Mutex` is correct and consistent. No need for `parking_lot`.
+
+---
+
+### Task 1: Create consciousness types and ConsciousnessEvent enum
+
+**Files:**
+- Create: `crates/arcand/src/consciousness.rs`
+- Modify: `crates/arcand/src/lib.rs`
+
+- [ ] **Step 1: Create consciousness.rs with module doc and imports**
+
+```rust
+//! Session consciousness — event-driven actor loop for concurrent message handling.
+//!
+//! Each session gets a long-lived `tokio::spawn` task (the "consciousness actor")
+//! that owns a `tokio::select!` event loop. HTTP handlers become thin event-pushers
+//! that return 202 Accepted. All results flow via the existing SSE streaming.
+//!
+//! Feature-flagged behind `ARCAN_CONSCIOUSNESS=true`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use aios_protocol::{BranchId, EventKind, OperatingMode, SessionId, SteeringMode, ToolCall};
+use aios_runtime::{KernelRuntime, TickInput, TickOutput};
+use arcan_core::queue::{MessageQueue, QueueConfig, QueuedMessage, SteeringAction};
+use arcan_core::runtime::SwappableProviderHandle;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tokio::time::Interval;
+use tracing::{Instrument, info, warn, debug, error};
+```
+
+- [ ] **Step 2: Define ConsciousnessEvent enum**
+
+```rust
+/// Unified stimulus enum — every input to the consciousness actor.
+#[derive(Debug)]
+pub enum ConsciousnessEvent {
+    /// User message from HTTP POST /runs or /messages.
+    UserMessage {
+        objective: String,
+        branch: BranchId,
+        steering: SteeringMode,
+        /// Acknowledgment channel: actor sends back the session_id once queued/started.
+        ack: Option<oneshot::Sender<ConsciousnessAck>>,
+        /// Pre-built run context (system prompt, allowed tools, proposed tool).
+        run_context: RunContext,
+    },
+    /// Tool execution completed successfully (future: async tool execution).
+    ToolResult {
+        call_id: String,
+        tool_name: String,
+        result: serde_json::Value,
+        duration_ms: u64,
+    },
+    /// Tool execution failed (future: async tool execution).
+    ToolFailed {
+        call_id: String,
+        tool_name: String,
+        error: String,
+    },
+    /// Message from Spaces distributed networking (future: Phase 4).
+    SpacesMessage {
+        channel_id: String,
+        sender: String,
+        content: String,
+    },
+    /// Autonomic homeostasis signal (future: Phase 3).
+    AutonomicSignal {
+        ruling: String,
+    },
+    /// Timer tick from internal intervals.
+    TimerTick {
+        tick_type: TimerTickType,
+    },
+    /// Approval resolved from HTTP POST /approvals (future: Phase 2).
+    ApprovalResolved {
+        approval_id: String,
+        approved: bool,
+        actor: String,
+    },
+    /// External signal from webhook or scheduled task (future).
+    ExternalSignal {
+        signal_type: String,
+        data: serde_json::Value,
+    },
+    /// Graceful shutdown request.
+    Shutdown,
+}
+
+/// Timer tick types for the consciousness heartbeat.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimerTickType {
+    Heartbeat,
+    IdleCheck,
+    SleepWake,
+}
+
+/// Pre-built context for an agent run (passed from HTTP handler).
+#[derive(Debug, Clone)]
+pub struct RunContext {
+    pub system_prompt: Option<String>,
+    pub allowed_tools: Option<Vec<String>>,
+    pub proposed_tool: Option<ToolCall>,
+}
+
+/// Acknowledgment sent back to the HTTP handler after event is received.
+#[derive(Debug)]
+pub enum ConsciousnessAck {
+    /// Event was accepted; run started or queued.
+    Accepted { queued: bool },
+    /// Event was rejected (e.g., shutting down).
+    Rejected { reason: String },
+}
+```
+
+- [ ] **Step 3: Define ConsciousnessMode and ConsciousnessState**
+
+```rust
+/// Operating mode of the consciousness actor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsciousnessMode {
+    /// Actively running an agent cycle.
+    Active,
+    /// Waiting for background tool results (future: async tools).
+    WaitingForTools,
+    /// No active work — ready for new messages.
+    Idle,
+    /// Low-power mode after extended inactivity.
+    Sleeping,
+    /// Gracefully shutting down.
+    ShuttingDown,
+}
+
+/// Per-session mutable state owned by the consciousness actor.
+struct ConsciousnessState {
+    session_id: SessionId,
+    branch: BranchId,
+    mode: ConsciousnessMode,
+    queue: MessageQueue,
+    running_tools: HashMap<String, RunningToolInfo>,
+    active_run_id: Option<String>,
+    last_activity: Instant,
+    stall_counter: u32,
+}
+
+/// Metadata for a running tool (future: async tool execution).
+#[derive(Debug, Clone)]
+pub struct RunningToolInfo {
+    pub tool_name: String,
+    pub started_at: Instant,
+}
+
+impl ConsciousnessState {
+    fn new(session_id: SessionId, branch: BranchId) -> Self {
+        Self {
+            session_id,
+            branch,
+            mode: ConsciousnessMode::Idle,
+            queue: MessageQueue::new(QueueConfig::default()),
+            running_tools: HashMap::new(),
+            active_run_id: None,
+            last_activity: Instant::now(),
+            stall_counter: 0,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Register the module in lib.rs**
+
+In `crates/arcand/src/lib.rs`, add:
+
+```rust
+pub mod consciousness;
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `cd /Users/broomva/broomva/core/life/arcan && cargo check -p arcand`
+Expected: Compiles with possible warnings about unused types (expected at this stage).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/arcand/src/consciousness.rs crates/arcand/src/lib.rs
+git commit -m "feat(consciousness): add ConsciousnessEvent types and state (BRO-455)"
+```
+
+---
+
+### Task 2: Implement SessionConsciousness actor and main event loop
+
+**Files:**
+- Modify: `crates/arcand/src/consciousness.rs`
+
+- [ ] **Step 1: Write test for actor creation and shutdown**
+
+Append to `consciousness.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_runtime() -> Arc<KernelRuntime> {
+        // KernelRuntime requires ports — use a minimal mock setup.
+        // For consciousness tests we only need the runtime reference;
+        // actual tick_on_branch calls are tested in integration tests.
+        // We'll use a real KernelRuntime with mock ports.
+        use aios_runtime::KernelRuntime;
+        Arc::new(KernelRuntime::new(
+            aios_runtime::RuntimeConfig::default(),
+            Arc::new(aios_events::InMemoryEventStore::new()),
+            Arc::new(arcan_core::runtime::MockProvider),
+            Arc::new(aios_tools::NoOpToolHarness),
+            Arc::new(aios_policy::DefaultApprovalPort),
+            Arc::new(aios_policy::DefaultPolicyGate),
+        ))
+    }
+
+    #[tokio::test]
+    async fn actor_shuts_down_on_shutdown_event() {
+        let runtime = test_runtime();
+        let session_id = SessionId::from_string("test-shutdown".to_string());
+        let branch = BranchId::main();
+
+        let (handle, tx) = SessionConsciousness::spawn(
+            session_id,
+            branch,
+            runtime,
+            ConsciousnessConfig::default(),
+        );
+
+        // Send shutdown
+        tx.send(ConsciousnessEvent::Shutdown).await.unwrap();
+
+        // Actor should exit cleanly
+        let result = tokio::time::timeout(Duration::from_secs(2), handle).await;
+        assert!(result.is_ok(), "actor should shut down within 2s");
+    }
+
+    #[tokio::test]
+    async fn actor_starts_in_idle_mode() {
+        let runtime = test_runtime();
+        let session_id = SessionId::from_string("test-idle".to_string());
+        let branch = BranchId::main();
+
+        let (handle, tx) = SessionConsciousness::spawn(
+            session_id,
+            branch,
+            runtime,
+            ConsciousnessConfig::default(),
+        );
+
+        // Give actor time to start
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Shutdown and verify it was running
+        tx.send(ConsciousnessEvent::Shutdown).await.unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(2), handle).await;
+        assert!(result.is_ok());
+    }
+}
+```
+
+- [ ] **Step 2: Define ConsciousnessConfig**
+
+Add above the `SessionConsciousness` struct:
+
+```rust
+/// Configuration for the consciousness actor.
+#[derive(Debug, Clone)]
+pub struct ConsciousnessConfig {
+    /// Channel buffer size for incoming events.
+    pub channel_buffer: usize,
+    /// Heartbeat interval (default: 30s).
+    pub heartbeat_interval: Duration,
+    /// Idle check interval (default: 60s).
+    pub idle_check_interval: Duration,
+    /// Max agent iterations per run (default: 10).
+    pub max_agent_iterations: u32,
+    /// Time before transitioning from Idle to Sleeping (default: 5min).
+    pub idle_to_sleep: Duration,
+}
+
+impl Default for ConsciousnessConfig {
+    fn default() -> Self {
+        Self {
+            channel_buffer: 32,
+            heartbeat_interval: Duration::from_secs(30),
+            idle_check_interval: Duration::from_secs(60),
+            max_agent_iterations: 10,
+            idle_to_sleep: Duration::from_secs(300),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Implement SessionConsciousness struct and spawn**
+
+```rust
+/// The consciousness actor — a long-lived tokio task per session.
+pub struct SessionConsciousness {
+    rx: mpsc::Receiver<ConsciousnessEvent>,
+    state: ConsciousnessState,
+    runtime: Arc<KernelRuntime>,
+    config: ConsciousnessConfig,
+}
+
+impl SessionConsciousness {
+    /// Spawn a new consciousness actor for the given session.
+    ///
+    /// Returns the `JoinHandle` and a `Sender` for pushing events.
+    pub fn spawn(
+        session_id: SessionId,
+        branch: BranchId,
+        runtime: Arc<KernelRuntime>,
+        config: ConsciousnessConfig,
+    ) -> (JoinHandle<()>, mpsc::Sender<ConsciousnessEvent>) {
+        let (tx, rx) = mpsc::channel(config.channel_buffer);
+        let actor = Self {
+            rx,
+            state: ConsciousnessState::new(session_id.clone(), branch),
+            runtime,
+            config,
+        };
+        let span = tracing::info_span!("consciousness", session = %session_id);
+        let handle = tokio::spawn(actor.run().instrument(span));
+        (handle, tx)
+    }
+
+    /// Main event loop — runs until Shutdown or channel closes.
+    async fn run(mut self) {
+        info!(
+            session = %self.state.session_id,
+            "consciousness actor started"
+        );
+
+        let mut heartbeat = tokio::time::interval(self.config.heartbeat_interval);
+        let mut idle_check = tokio::time::interval(self.config.idle_check_interval);
+        // Skip the immediate first tick (fires at interval creation).
+        heartbeat.tick().await;
+        idle_check.tick().await;
+
+        loop {
+            let event = tokio::select! {
+                biased;
+
+                // Prioritize incoming events over timers.
+                Some(e) = self.rx.recv() => e,
+
+                _ = heartbeat.tick() => ConsciousnessEvent::TimerTick {
+                    tick_type: TimerTickType::Heartbeat,
+                },
+
+                _ = idle_check.tick() => ConsciousnessEvent::TimerTick {
+                    tick_type: TimerTickType::IdleCheck,
+                },
+            };
+
+            match event {
+                ConsciousnessEvent::Shutdown => {
+                    info!(session = %self.state.session_id, "shutdown requested");
+                    self.state.mode = ConsciousnessMode::ShuttingDown;
+                    self.graceful_shutdown().await;
+                    break;
+                }
+                ConsciousnessEvent::UserMessage {
+                    objective,
+                    branch,
+                    steering,
+                    ack,
+                    run_context,
+                } => {
+                    self.handle_user_message(objective, branch, steering, ack, run_context)
+                        .await;
+                }
+                ConsciousnessEvent::TimerTick { tick_type } => {
+                    self.handle_timer_tick(tick_type).await;
+                }
+                // Future event types — log and skip for now.
+                ConsciousnessEvent::ToolResult { call_id, .. } => {
+                    debug!(call_id, "tool result received (async tools not yet implemented)");
+                }
+                ConsciousnessEvent::ToolFailed { call_id, .. } => {
+                    debug!(call_id, "tool failure received (async tools not yet implemented)");
+                }
+                ConsciousnessEvent::SpacesMessage { .. } => {
+                    debug!("spaces message received (Phase 4)");
+                }
+                ConsciousnessEvent::AutonomicSignal { .. } => {
+                    debug!("autonomic signal received (Phase 3)");
+                }
+                ConsciousnessEvent::ApprovalResolved { .. } => {
+                    debug!("approval resolved (Phase 2)");
+                }
+                ConsciousnessEvent::ExternalSignal { .. } => {
+                    debug!("external signal received");
+                }
+            }
+        }
+
+        info!(session = %self.state.session_id, "consciousness actor stopped");
+    }
+}
+```
+
+- [ ] **Step 4: Verify tests compile**
+
+Run: `cd /Users/broomva/broomva/core/life/arcan && cargo test -p arcand --lib consciousness -- --no-run`
+Expected: Compilation succeeds (tests not executed yet because mock types may need adjustment).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/arcand/src/consciousness.rs
+git commit -m "feat(consciousness): implement SessionConsciousness actor with event loop (BRO-455)"
+```
+
+---
+
+### Task 3: Implement handle_user_message and run_agent_cycle
+
+**Files:**
+- Modify: `crates/arcand/src/consciousness.rs`
+
+- [ ] **Step 1: Write test for user message when idle starts a run**
+
+```rust
+#[tokio::test]
+async fn user_message_when_idle_starts_run() {
+    let runtime = test_runtime();
+    let session_id = SessionId::from_string("test-run".to_string());
+    let branch = BranchId::main();
+
+    // Create session in runtime first
+    runtime
+        .create_session_with_id(
+            session_id.clone(),
+            "test",
+            aios_protocol::PolicySet::default(),
+            aios_protocol::ModelRouting::default(),
+        )
+        .await
+        .unwrap();
+
+    let (handle, tx) = SessionConsciousness::spawn(
+        session_id,
+        branch,
+        runtime,
+        ConsciousnessConfig {
+            max_agent_iterations: 1, // single tick for test
+            ..Default::default()
+        },
+    );
+
+    let (ack_tx, ack_rx) = oneshot::channel();
+    tx.send(ConsciousnessEvent::UserMessage {
+        objective: "Hello".to_string(),
+        branch: BranchId::main(),
+        steering: SteeringMode::Collect,
+        ack: Some(ack_tx),
+        run_context: RunContext {
+            system_prompt: None,
+            allowed_tools: None,
+            proposed_tool: None,
+        },
+    })
+    .await
+    .unwrap();
+
+    // Should get acknowledgment
+    let ack = tokio::time::timeout(Duration::from_secs(5), ack_rx).await;
+    assert!(ack.is_ok(), "should receive ack");
+    match ack.unwrap().unwrap() {
+        ConsciousnessAck::Accepted { queued } => {
+            assert!(!queued, "should start immediately when idle");
+        }
+        other => panic!("expected Accepted, got {other:?}"),
+    }
+
+    // Shutdown
+    tx.send(ConsciousnessEvent::Shutdown).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+}
+
+#[tokio::test]
+async fn user_message_when_active_queues() {
+    let runtime = test_runtime();
+    let session_id = SessionId::from_string("test-queue".to_string());
+    let branch = BranchId::main();
+
+    runtime
+        .create_session_with_id(
+            session_id.clone(),
+            "test",
+            aios_protocol::PolicySet::default(),
+            aios_protocol::ModelRouting::default(),
+        )
+        .await
+        .unwrap();
+
+    let config = ConsciousnessConfig {
+        max_agent_iterations: 1,
+        ..Default::default()
+    };
+    let (handle, tx) = SessionConsciousness::spawn(
+        session_id, branch, runtime, config,
+    );
+
+    // Send first message (starts run)
+    let (ack1_tx, _ack1_rx) = oneshot::channel();
+    tx.send(ConsciousnessEvent::UserMessage {
+        objective: "First".to_string(),
+        branch: BranchId::main(),
+        steering: SteeringMode::Collect,
+        ack: Some(ack1_tx),
+        run_context: RunContext {
+            system_prompt: None,
+            allowed_tools: None,
+            proposed_tool: None,
+        },
+    })
+    .await
+    .unwrap();
+
+    // Small delay then send second message while first is running
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let (ack2_tx, ack2_rx) = oneshot::channel();
+    tx.send(ConsciousnessEvent::UserMessage {
+        objective: "Second".to_string(),
+        branch: BranchId::main(),
+        steering: SteeringMode::Collect,
+        ack: Some(ack2_tx),
+        run_context: RunContext {
+            system_prompt: None,
+            allowed_tools: None,
+            proposed_tool: None,
+        },
+    })
+    .await
+    .unwrap();
+
+    // Second message should be queued
+    if let Ok(Ok(ack)) = tokio::time::timeout(Duration::from_secs(5), ack2_rx).await {
+        match ack {
+            ConsciousnessAck::Accepted { queued } => {
+                assert!(queued, "second message should be queued");
+            }
+            other => panic!("expected Accepted(queued=true), got {other:?}"),
+        }
+    }
+
+    tx.send(ConsciousnessEvent::Shutdown).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+}
+```
+
+- [ ] **Step 2: Implement handle_user_message**
+
+Add to `impl SessionConsciousness`:
+
+```rust
+    /// Handle an incoming user message.
+    ///
+    /// If idle, start a new agent cycle immediately.
+    /// If active, queue the message with the specified steering mode.
+    async fn handle_user_message(
+        &mut self,
+        objective: String,
+        branch: BranchId,
+        steering: SteeringMode,
+        ack: Option<oneshot::Sender<ConsciousnessAck>>,
+        run_context: RunContext,
+    ) {
+        self.state.last_activity = Instant::now();
+        self.state.branch = branch.clone();
+
+        match self.state.mode {
+            ConsciousnessMode::Idle | ConsciousnessMode::Sleeping => {
+                // Start a new run immediately.
+                if let Some(ack) = ack {
+                    let _ = ack.send(ConsciousnessAck::Accepted { queued: false });
+                }
+                self.state.mode = ConsciousnessMode::Active;
+                self.run_agent_cycle(objective, branch, run_context).await;
+                self.drain_queue_after_run().await;
+            }
+            ConsciousnessMode::Active | ConsciousnessMode::WaitingForTools => {
+                // Queue the message for later processing.
+                let msg_id = uuid::Uuid::new_v4().to_string();
+                let queued = QueuedMessage {
+                    id: msg_id.clone(),
+                    mode: steering,
+                    content: objective,
+                    queued_at: None, // set by enqueue()
+                };
+                match self.state.queue.enqueue(queued) {
+                    Ok(()) => {
+                        info!(msg_id, "message queued during active run");
+                        // Record queue event via runtime.
+                        let _ = self
+                            .runtime
+                            .record_external_event(
+                                &self.state.session_id,
+                                EventKind::Queued {
+                                    queue_id: msg_id,
+                                    mode: steering,
+                                    message: String::new(), // content already in queue
+                                },
+                            )
+                            .await;
+                        if let Some(ack) = ack {
+                            let _ = ack.send(ConsciousnessAck::Accepted { queued: true });
+                        }
+                    }
+                    Err(err) => {
+                        warn!(%err, "failed to queue message");
+                        if let Some(ack) = ack {
+                            let _ = ack.send(ConsciousnessAck::Rejected {
+                                reason: err.to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+            ConsciousnessMode::ShuttingDown => {
+                if let Some(ack) = ack {
+                    let _ = ack.send(ConsciousnessAck::Rejected {
+                        reason: "session is shutting down".to_string(),
+                    });
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Implement run_agent_cycle**
+
+```rust
+    /// Run the agent loop: tick repeatedly until end_turn or max iterations.
+    ///
+    /// This is the core agent cycle, equivalent to the existing blocking loop
+    /// in `canonical.rs` run_session handler (lines 1608-1657).
+    async fn run_agent_cycle(
+        &mut self,
+        objective: String,
+        branch: BranchId,
+        run_context: RunContext,
+    ) {
+        let run_id = uuid::Uuid::new_v4().to_string();
+        self.state.active_run_id = Some(run_id.clone());
+        self.state.queue.set_active_run(true).ok();
+
+        debug!(run_id, objective = %objective, "starting agent cycle");
+
+        let agent_span = life_vigil::spans::agent_span(
+            self.state.session_id.as_str(),
+            "arcan",
+        );
+
+        // First tick with the actual objective.
+        let mut tick_result = self
+            .runtime
+            .tick_on_branch(
+                &self.state.session_id,
+                &branch,
+                TickInput {
+                    objective,
+                    proposed_tool: run_context.proposed_tool,
+                    system_prompt: run_context.system_prompt.clone(),
+                    allowed_tools: run_context.allowed_tools.clone(),
+                },
+            )
+            .instrument(agent_span.clone())
+            .await;
+
+        // Continue ticking while mode=Execute (tools ran, need continuation).
+        for iteration in 1..self.config.max_agent_iterations {
+            match &tick_result {
+                Ok(tick) if tick.mode == OperatingMode::Execute => {
+                    // Check preemption at tool boundary.
+                    match self.state.queue.check_preemption() {
+                        Ok(SteeringAction::Abort { reason }) => {
+                            warn!(iteration, %reason, "run aborted by interrupt");
+                            let _ = self
+                                .runtime
+                                .record_external_event(
+                                    &self.state.session_id,
+                                    EventKind::Steered {
+                                        queue_id: run_id.clone(),
+                                        preempted_at: format!("iteration:{iteration}"),
+                                    },
+                                )
+                                .await;
+                            break;
+                        }
+                        Ok(SteeringAction::CompleteAndSwitch(msg)) => {
+                            info!(
+                                iteration,
+                                msg_id = %msg.id,
+                                "steering: completing current iteration then switching"
+                            );
+                            let _ = self
+                                .runtime
+                                .record_external_event(
+                                    &self.state.session_id,
+                                    EventKind::Steered {
+                                        queue_id: msg.id.clone(),
+                                        preempted_at: format!("iteration:{iteration}"),
+                                    },
+                                )
+                                .await;
+                            // Re-queue as the next objective to run after drain.
+                            let requeue = QueuedMessage {
+                                id: msg.id,
+                                mode: SteeringMode::Followup,
+                                content: msg.content,
+                                queued_at: None,
+                            };
+                            self.state.queue.enqueue(requeue).ok();
+                            break;
+                        }
+                        Ok(SteeringAction::InjectMessage(_)) => {
+                            // Not yet implemented — treat as continue.
+                        }
+                        Ok(SteeringAction::Continue) => {}
+                        Err(err) => {
+                            warn!(%err, "preemption check failed, continuing");
+                        }
+                    }
+
+                    debug!(iteration, "agent loop: continuing after tool execution");
+                    tick_result = self
+                        .runtime
+                        .tick_on_branch(
+                            &self.state.session_id,
+                            &branch,
+                            TickInput {
+                                objective: String::new(),
+                                proposed_tool: None,
+                                system_prompt: run_context.system_prompt.clone(),
+                                allowed_tools: run_context.allowed_tools.clone(),
+                            },
+                        )
+                        .instrument(agent_span.clone())
+                        .await;
+                }
+                _ => break,
+            }
+        }
+
+        self.state.active_run_id = None;
+        self.state.queue.set_active_run(false).ok();
+
+        match tick_result {
+            Ok(tick) => {
+                debug!(
+                    mode = ?tick.mode,
+                    events = tick.events_emitted,
+                    "agent cycle completed"
+                );
+            }
+            Err(err) => {
+                error!(%err, "agent cycle failed");
+            }
+        }
+
+        self.state.mode = ConsciousnessMode::Idle;
+        self.state.last_activity = Instant::now();
+    }
+```
+
+- [ ] **Step 4: Implement drain_queue_after_run**
+
+```rust
+    /// Process queued messages after a run completes.
+    async fn drain_queue_after_run(&mut self) {
+        let drained = match self.state.queue.drain_after_run() {
+            Ok(msgs) => msgs,
+            Err(err) => {
+                warn!(%err, "failed to drain queue");
+                return;
+            }
+        };
+
+        if drained.is_empty() {
+            return;
+        }
+
+        let count = drained.len();
+        info!(count, "draining queued messages after run");
+
+        let _ = self
+            .runtime
+            .record_external_event(
+                &self.state.session_id,
+                EventKind::QueueDrained {
+                    queue_id: "post-run-drain".to_string(),
+                    processed: count,
+                },
+            )
+            .await;
+
+        // Process each drained message as a new run.
+        for msg in drained {
+            self.state.mode = ConsciousnessMode::Active;
+            self.run_agent_cycle(
+                msg.content,
+                self.state.branch.clone(),
+                RunContext {
+                    system_prompt: None,
+                    allowed_tools: None,
+                    proposed_tool: None,
+                },
+            )
+            .await;
+        }
+    }
+```
+
+- [ ] **Step 5: Implement handle_timer_tick and graceful_shutdown**
+
+```rust
+    /// Handle timer ticks (heartbeat, idle check).
+    async fn handle_timer_tick(&mut self, tick_type: TimerTickType) {
+        match tick_type {
+            TimerTickType::Heartbeat => {
+                // Emit heartbeat event for observability.
+                let _ = self
+                    .runtime
+                    .record_external_event(
+                        &self.state.session_id,
+                        EventKind::Heartbeat,
+                    )
+                    .await;
+
+                // Check queue health.
+                if let Ok(warnings) = self.state.queue.health_check() {
+                    for w in &warnings {
+                        warn!(session = %self.state.session_id, "{w}");
+                    }
+                }
+            }
+            TimerTickType::IdleCheck => {
+                if self.state.mode == ConsciousnessMode::Idle
+                    && self.state.last_activity.elapsed() > self.config.idle_to_sleep
+                {
+                    info!(
+                        session = %self.state.session_id,
+                        idle_secs = self.state.last_activity.elapsed().as_secs(),
+                        "transitioning to sleeping mode"
+                    );
+                    self.state.mode = ConsciousnessMode::Sleeping;
+                }
+            }
+            TimerTickType::SleepWake => {
+                // Future: periodic check if sleeping actor should wake.
+            }
+        }
+    }
+
+    /// Graceful shutdown: wait for running tools, emit final heartbeat.
+    async fn graceful_shutdown(&mut self) {
+        if !self.state.running_tools.is_empty() {
+            info!(
+                tools = self.state.running_tools.len(),
+                "waiting for running tools before shutdown"
+            );
+            // Future: wait for async tools with timeout.
+        }
+
+        // Emit final heartbeat.
+        let _ = self
+            .runtime
+            .record_external_event(
+                &self.state.session_id,
+                EventKind::Heartbeat,
+            )
+            .await;
+
+        info!(session = %self.state.session_id, "graceful shutdown complete");
+    }
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd /Users/broomva/broomva/core/life/arcan && cargo test -p arcand --lib consciousness`
+Expected: Tests pass (mock provider returns immediately, so agent cycle completes quickly).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/arcand/src/consciousness.rs
+git commit -m "feat(consciousness): implement handle_user_message, run_agent_cycle, queue drain (BRO-455)"
+```
+
+---
+
+### Task 4: Implement ConsciousnessRegistry and ConsciousnessHandle
+
+**Files:**
+- Modify: `crates/arcand/src/consciousness.rs`
+
+- [ ] **Step 1: Write tests for registry**
+
+```rust
+#[tokio::test]
+async fn registry_creates_and_retrieves_handle() {
+    let runtime = test_runtime();
+    let registry = ConsciousnessRegistry::new(ConsciousnessConfig::default());
+
+    let session_id = "test-registry";
+    let handle = registry.get_or_create(
+        session_id,
+        BranchId::main(),
+        runtime.clone(),
+    );
+    assert!(handle.is_alive());
+
+    // Second call returns same handle.
+    let handle2 = registry.get_or_create(
+        session_id,
+        BranchId::main(),
+        runtime,
+    );
+    assert!(handle2.is_alive());
+
+    // Shutdown all.
+    registry.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn registry_shutdown_all_stops_actors() {
+    let runtime = test_runtime();
+    let registry = ConsciousnessRegistry::new(ConsciousnessConfig::default());
+
+    registry.get_or_create("s1", BranchId::main(), runtime.clone());
+    registry.get_or_create("s2", BranchId::main(), runtime);
+
+    assert_eq!(registry.session_count(), 2);
+
+    registry.shutdown_all().await;
+    // After shutdown, actors should be stopped.
+    // (handles are consumed by shutdown_all)
+}
+```
+
+- [ ] **Step 2: Implement ConsciousnessHandle**
+
+```rust
+/// Handle for communicating with a consciousness actor.
+#[derive(Clone)]
+pub struct ConsciousnessHandle {
+    pub tx: mpsc::Sender<ConsciousnessEvent>,
+    join: Arc<Mutex<Option<JoinHandle<()>>>>,
+}
+
+impl ConsciousnessHandle {
+    fn new(tx: mpsc::Sender<ConsciousnessEvent>, join: JoinHandle<()>) -> Self {
+        Self {
+            tx,
+            join: Arc::new(Mutex::new(Some(join))),
+        }
+    }
+
+    /// Check if the actor task is still running.
+    pub fn is_alive(&self) -> bool {
+        self.join
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .is_some_and(|h| !h.is_finished())
+    }
+
+    /// Send an event to the consciousness actor.
+    pub async fn send(&self, event: ConsciousnessEvent) -> Result<(), mpsc::error::SendError<ConsciousnessEvent>> {
+        self.tx.send(event).await
+    }
+
+    /// Send a shutdown event and wait for the actor to stop.
+    pub async fn shutdown(self) {
+        let _ = self.tx.send(ConsciousnessEvent::Shutdown).await;
+        let join = self
+            .join
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(handle) = join {
+            let _ = tokio::time::timeout(Duration::from_secs(10), handle).await;
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Implement ConsciousnessRegistry**
+
+```rust
+/// Registry mapping session IDs to consciousness actors.
+///
+/// Thread-safe: accessed from HTTP handlers (multiple threads) and
+/// from the actors themselves. Lock is never held across `.await`.
+pub struct ConsciousnessRegistry {
+    sessions: Mutex<HashMap<String, ConsciousnessHandle>>,
+    config: ConsciousnessConfig,
+}
+
+impl ConsciousnessRegistry {
+    pub fn new(config: ConsciousnessConfig) -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+            config,
+        }
+    }
+
+    /// Get an existing handle or create a new consciousness actor.
+    pub fn get_or_create(
+        &self,
+        session_id: &str,
+        branch: BranchId,
+        runtime: Arc<KernelRuntime>,
+    ) -> ConsciousnessHandle {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Return existing if alive.
+        if let Some(handle) = sessions.get(session_id) {
+            if handle.is_alive() {
+                return handle.clone();
+            }
+            // Dead actor — remove and create new.
+            sessions.remove(session_id);
+        }
+
+        // Spawn new actor.
+        let (join, tx) = SessionConsciousness::spawn(
+            SessionId::from_string(session_id.to_string()),
+            branch,
+            runtime,
+            self.config.clone(),
+        );
+        let handle = ConsciousnessHandle::new(tx, join);
+        sessions.insert(session_id.to_string(), handle.clone());
+
+        info!(session_id, "consciousness actor created");
+        handle
+    }
+
+    /// Get an existing handle (returns None if no actor for this session).
+    pub fn get(&self, session_id: &str) -> Option<ConsciousnessHandle> {
+        let sessions = self
+            .sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        sessions.get(session_id).filter(|h| h.is_alive()).cloned()
+    }
+
+    /// Number of active sessions.
+    pub fn session_count(&self) -> usize {
+        let sessions = self
+            .sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        sessions.values().filter(|h| h.is_alive()).count()
+    }
+
+    /// Shut down all consciousness actors gracefully.
+    pub async fn shutdown_all(&self) {
+        let handles: Vec<ConsciousnessHandle> = {
+            let mut sessions = self
+                .sessions
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            sessions.drain().map(|(_, h)| h).collect()
+        };
+
+        info!(count = handles.len(), "shutting down all consciousness actors");
+
+        let futures: Vec<_> = handles.into_iter().map(|h| h.shutdown()).collect();
+        futures_util::future::join_all(futures).await;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /Users/broomva/broomva/core/life/arcan && cargo test -p arcand --lib consciousness`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/arcand/src/consciousness.rs
+git commit -m "feat(consciousness): implement ConsciousnessRegistry and ConsciousnessHandle (BRO-455)"
+```
+
+---
+
+### Task 5: Wire ConsciousnessRegistry into CanonicalState and feature-flag run_session
+
+**Files:**
+- Modify: `crates/arcand/src/canonical.rs`
+- Modify: `crates/arcand/Cargo.toml` (add `futures-util` if not present)
+
+- [ ] **Step 1: Add futures-util to arcand dependencies (if needed)**
+
+Check if `futures-util` is already in arcand's Cargo.toml. If not, add:
+
+```toml
+futures-util.workspace = true
+```
+
+- [ ] **Step 2: Add consciousness_registry field to CanonicalState**
+
+In `crates/arcand/src/canonical.rs`, add to the `CanonicalState` struct (after `cached_git_context`):
+
+```rust
+    /// Consciousness registry for event-driven session actors (BRO-455).
+    /// When `ARCAN_CONSCIOUSNESS=true`, run_session pushes events to actors
+    /// instead of blocking on the tick loop.
+    consciousness_registry: Option<Arc<crate::consciousness::ConsciousnessRegistry>>,
+```
+
+- [ ] **Step 3: Initialize the registry in create_canonical_router_with_skills**
+
+In the `state = CanonicalState { ... }` block, add:
+
+```rust
+        consciousness_registry: if std::env::var("ARCAN_CONSCIOUSNESS")
+            .is_ok_and(|v| v == "true" || v == "1")
+        {
+            tracing::info!("Consciousness mode ENABLED (BRO-455)");
+            Some(Arc::new(crate::consciousness::ConsciousnessRegistry::new(
+                crate::consciousness::ConsciousnessConfig::default(),
+            )))
+        } else {
+            None
+        },
+```
+
+- [ ] **Step 4: Modify run_session to use consciousness when enabled**
+
+After the system prompt is built and combined_allowed_tools is computed (around line 1572), insert the consciousness dispatch path before the existing agent loop:
+
+```rust
+    // ─── Consciousness dispatch (BRO-455) ────────────────────────────
+    // When ARCAN_CONSCIOUSNESS=true, push the message to the session's
+    // consciousness actor instead of blocking on the tick loop.
+    if let Some(ref registry) = state.consciousness_registry {
+        let handle = registry.get_or_create(
+            session_id.as_str(),
+            branch.clone(),
+            state.runtime.clone(),
+        );
+
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        let send_result = handle
+            .send(crate::consciousness::ConsciousnessEvent::UserMessage {
+                objective: objective.clone(),
+                branch: branch.clone(),
+                steering: aios_protocol::SteeringMode::Collect,
+                ack: Some(ack_tx),
+                run_context: crate::consciousness::RunContext {
+                    system_prompt: system_prompt.clone(),
+                    allowed_tools: combined_allowed_tools.clone(),
+                    proposed_tool: proposed_tool.clone(),
+                },
+            })
+            .await;
+
+        if send_result.is_err() {
+            return Err(internal_error(anyhow::anyhow!(
+                "consciousness actor for session {} is not running",
+                session_id
+            )));
+        }
+
+        // Wait for acknowledgment (fast — actor responds immediately).
+        match tokio::time::timeout(Duration::from_secs(5), ack_rx).await {
+            Ok(Ok(crate::consciousness::ConsciousnessAck::Accepted { queued })) => {
+                // Return a response indicating the run was accepted.
+                // The actual results flow via SSE streaming.
+                return Ok(Json(RunResponse {
+                    session_id,
+                    mode: if queued {
+                        OperatingMode::Execute
+                    } else {
+                        OperatingMode::Execute
+                    },
+                    state: AgentStateVector::default(),
+                    events_emitted: 0,
+                    last_sequence: 0,
+                }));
+            }
+            Ok(Ok(crate::consciousness::ConsciousnessAck::Rejected { reason })) => {
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({ "error": "consciousness_rejected", "reason": reason })),
+                ));
+            }
+            Ok(Err(_)) => {
+                return Err(internal_error(anyhow::anyhow!(
+                    "consciousness actor dropped ack channel"
+                )));
+            }
+            Err(_) => {
+                return Err((
+                    StatusCode::GATEWAY_TIMEOUT,
+                    Json(json!({ "error": "consciousness_timeout" })),
+                ));
+            }
+        }
+    }
+    // ─── End consciousness dispatch ──────────────────────────────────
+```
+
+- [ ] **Step 5: Run cargo check**
+
+Run: `cd /Users/broomva/broomva/core/life/arcan && cargo check -p arcand`
+Expected: Compiles without errors.
+
+- [ ] **Step 6: Run cargo fmt and clippy**
+
+Run: `cd /Users/broomva/broomva/core/life/arcan && cargo fmt && cargo clippy -p arcand`
+Expected: No warnings.
+
+- [ ] **Step 7: Run full workspace tests**
+
+Run: `cd /Users/broomva/broomva/core/life/arcan && cargo test --workspace`
+Expected: All existing tests pass plus new consciousness tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/arcand/src/canonical.rs crates/arcand/src/consciousness.rs crates/arcand/Cargo.toml
+git commit -m "feat(consciousness): wire registry into CanonicalState with ARCAN_CONSCIOUSNESS flag (BRO-455)"
+```
+
+---
+
+### Task 6: Final validation, format, and cleanup
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Full validation**
+
+```bash
+cd /Users/broomva/broomva/core/life/arcan
+cargo fmt
+cargo clippy --workspace
+cargo test --workspace
+cargo build --workspace
+```
+
+Expected: All green.
+
+- [ ] **Step 2: Update BRO-455 status to In Progress**
+
+Update the Linear ticket status.
+
+- [ ] **Step 3: Create feature branch and PR**
+
+```bash
+git checkout -b feature/bro-455-consciousness-actor-loop
+git push -u origin feature/bro-455-consciousness-actor-loop
+```
+
+Create PR with summary of changes.


### PR DESCRIPTION
## Summary

- Implement per-session consciousness actors with `tokio::select!` event loops that replace the blocking `run_session` handler when `ARCAN_CONSCIOUSNESS=true`
- Add `ConsciousnessRegistry` mapping session IDs to actor handles, with `get_or_create`, `get`, and `shutdown_all`
- Fix and export `arcan-core::queue` module (was private/uncompiled) — MessageQueue with steering semantics (Collect/Steer/Followup/Interrupt)
- Feature-flagged: existing blocking behavior is unchanged when env var is not set

### New files
- `crates/arcand/src/consciousness.rs` — types, actor, registry, handle (~640 lines)
- `crates/arcand/tests/consciousness_test.rs` — 5 integration tests
- `docs/superpowers/plans/2026-04-04-consciousness-actor-loop.md` — implementation plan

### Modified files
- `crates/arcand/src/canonical.rs` — consciousness dispatch in `run_session`, registry in `CanonicalState`
- `crates/arcan-core/src/queue.rs` — fix compilation bugs (return types, trait impl)
- `crates/arcan-core/src/lib.rs` — export `pub mod queue`

## Test plan

- [x] 5 integration tests: shutdown, idle message acceptance, registry create/retrieve, shutdown_all, channel close
- [x] 15 unit tests for MessageQueue (queue.rs)
- [x] Full workspace: 1085 tests passing, 0 failures
- [x] `cargo clippy --workspace` — zero warnings
- [x] `cargo build --workspace` — clean build
- [ ] Manual test: `ARCAN_CONSCIOUSNESS=true cargo run -p arcan` + curl POST /runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consciousness mode: per-session, event-driven actor system for managed agent runs with configurable heartbeat, idle timeouts, and iteration limits.

* **Improvements**
  * Queue operations now surface errors consistently, improving robustness around enqueueing, draining, preemption checks, and status/health reporting.

* **Tests**
  * New integration tests validating actor lifecycle, message handling, registry behavior, and shutdown semantics.

* **Documentation**
  * Added implementation plan and design notes for the consciousness actor loop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->